### PR TITLE
Revise start project links

### DIFF
--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -151,6 +151,13 @@ nav .fa-comment {
 .jumbotron.event-page {
   margin-top: 40px;
 }
+
+.with-event .start-project {
+  margin: 2em 0px;
+  text-align: center;
+  display: block;
+}
+
 .event-page .honeycomb {
   margin: 30px 0px 100px 0px;
   text-align: left;

--- a/dribdat/static/js/script.js
+++ b/dribdat/static/js/script.js
@@ -83,7 +83,8 @@
         $button.removeAttr('disabled').html('Update now');
 
         if (typeof data.name === 'undefined' || data.name === '') {
-          window.alert('Project data could not be fetched - please check your link.');
+          window.alert('Project data could not be fetched - enter a valid Remote link.');
+          $('#is_autoupdate').prop('checked', false);
           return;
         }
 

--- a/dribdat/templates/nav.html
+++ b/dribdat/templates/nav.html
@@ -40,8 +40,16 @@
             {% endif %}
       	  </a>
         </li>
+        {% if event.has_started %}
         <li>
-          <a href="{{ event.community_url }}" target="_blank">Community
+          <a href="{{ url_for('public.project_new') }}">
+            Get started
+            <i class="fa fa-flag"></i></a>
+        </li>
+        {% endif %}
+        <li>
+          <a href="{{ event.community_url }}" target="_blank">
+            Community
             <i class="fa fa-comment"></i></a>
         </li>
       {% endif %}

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -28,13 +28,6 @@
             <span> </span>
         </label>
       </div>
-
-      {% if current_event.has_started %}
-        <a href="{{ url_for('public.project_new') }}" class="btn btn-success" style="opacity:1">
-          <i class="fa fa-flag"></i><br>
-          <span>Start&nbsp;project</span>
-        </a>
-      {% endif %}
     </div>
 
   </center>
@@ -84,6 +77,15 @@
     {% endfor %}
   {% endif %}
   </div>
+
+  {% if current_event.has_started %}
+    <div class="start-project">
+      <a href="{{ url_for('public.project_new') }}" class="btn btn-lg btn-success">
+        <span>Start a project</span>
+        <i class="fa fa-flag"></i>
+      </a>
+    </div>
+  {% endif %}
 
 </div>
 

--- a/dribdat/templates/public/home.html
+++ b/dribdat/templates/public/home.html
@@ -21,8 +21,8 @@
         </b></a>
         {% if current_user and current_user.is_authenticated and current_event.has_started %}
           <a href="{{ url_for('public.project_new') }}" class="btn btn-success">
-            <i class="fa fa-flag"></i>
-            Start a project!</a>
+            Start a project
+            <i class="fa fa-flag"></i></a>
         {% endif %}
       </div>
     </center>


### PR DESCRIPTION
The Start button is now centered under the category detail view in the event page, instead of hanging off the category nav. A link to "Get started" is also added to the primary navigation, with minor adjustments to the formatting also on the home page. Plus a fix to the JavaScript makes it clearer what to do when the Remote link is invalid.