### PR TITLE
Release: update project refs to mainline

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -1,8 +1,8 @@
-This document summarises the current status and makes some vision statements about possible future developments as discussed in [issue #100](https://github.com/loleg/dribdat/issues/100).
+This document summarises the current status and makes some vision statements about possible future developments as discussed in [issue #100](https://github.com/datalets/dribdat/issues/100).
 
 # About Dribdat
 
-[![](https://blog.datalets.ch/workshops/2017/dribdat/dribdat.png)](https://github.com/loleg/dribdat/)
+[![](https://blog.datalets.ch/workshops/2017/dribdat/dribdat.png)](https://github.com/datalets/dribdat/)
 
 Dribdat (from "Driven By Data") is an open source tool for data-driven team collaboration such as Hackathons. It provides an open source website and project board for running events, and integrates popular community platforms and open source code repositories. It is the official platform of Opendata.ch hackathons and School of Data Switzerland workshops.
 
@@ -38,7 +38,7 @@ Dribdat is a Web application written using the Flask framework for Python and B
 
 ### Links / contacts
 
-- Source: [github.com/loleg/dribdat](https://github.com/loleg/dribdat)
+- Source: [github.com/datalets/dribdat](https://github.com/datalets/dribdat)
 - Website: [datalets.ch/dribdat](https://datalets.ch/dribdat)
 - Discuss:  [forum.schoolofdata.ch](https://forum.schoolofdata.ch/search?q=dribdat)
 
@@ -96,7 +96,7 @@ Yes, there is a getting started page which can also be customized by the hackath
 
 _&gt; Please provide the page where we can find more information about the easy hacks._
 
-For deployment see [https://github.com/loleg/dribdat](https://github.com/loleg/dribdat)
+For deployment see [https://github.com/datalets/dribdat](https://github.com/datalets/dribdat)
 
 For usage notes, see [https://hack.opendata.ch/about/](https://hack.opendata.ch/about/)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Set the redirect URL in your app's OAuth Settings to `<SERVER_URL>/slack_callbac
 
 ## API
 
-There are a number of API calls that admins can use to easily get to the data in Dribdat in CSV or JSON format. See GitHub issues for [development status](https://github.com/loleg/dribdat/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+API).
+There are a number of API calls that admins can use to easily get to the data in Dribdat in CSV or JSON format. See GitHub issues for [development status](https://github.com/datalets/dribdat/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+API).
 
 Basic data on an event:
 
@@ -103,7 +103,7 @@ You may need to install additional libraries (`libffi`) for the [misaka](http://
 Run the following commands to bootstrap your environment.
 
 ```
-git clone https://github.com/loleg/dribdat
+git clone https://github.com/datalets/dribdat
 cd dribdat
 pip install -r requirements/dev.txt
 ```

--- a/dribdat/templates/footer.html
+++ b/dribdat/templates/footer.html
@@ -9,7 +9,7 @@
           <i style="-moz-transform: scale(-1, 1); -webkit-transform: scale(-1, 1); -o-transform: scale(-1, 1); -ms-transform: scale(-1, 1); transform: scale(-1, 1);" class="fa fa-thumbs-up"></i>
           A T</small></a></b>
       </li><li>
-        <a href="https://github.com/loleg/dribdat/issues">Issues</a>
+        <a href="https://github.com/datalets/dribdat/issues">Issues</a>
       </li>
     </ul>
   </small>

--- a/dribdat/templates/public/about.html
+++ b/dribdat/templates/public/about.html
@@ -31,8 +31,8 @@
         should be able to help you - or just fork the open source project
         and set it up to your liking:</p>
       <p>
-        <a href="https://github.com/loleg/dribdat/issues" class="btn btn-primary">Issues &raquo;</a>
-        <a href="https://github.com/loleg/dribdat" class="btn btn-default">Source code</a>
+        <a href="https://github.com/datalets/dribdat/issues" class="btn btn-primary">Issues &raquo;</a>
+        <a href="https://github.com/datalets/dribdat" class="btn btn-default">Source code</a>
       </p>
     </div>
   </div>

--- a/dribdat/templates/quickstart.html
+++ b/dribdat/templates/quickstart.html
@@ -2,4 +2,4 @@
 
 <p>After creating a project, you can customise the icon, color and image, and your team status. By updating your <b>Progress</b>, you can communicate how far along you are in development. Once your project is past the "Idea / Challenge" phase, your team members can click the <a href="#" class="btn btn-primary disabled btn-sm">Join</a> button at the top of your project page to link their profile and make changes.</p>
 
-<p><i>Need more help? Get in touch with the organising team using the <b>Community</b> links, or raise a <a href="https://github.com/loleg/dribdat/issues" target="_blank">GitHub issue</a>.</i></p>
+<p><i>Need more help? Get in touch with the organising team using the <b>Community</b> links, or raise a <a href="https://github.com/datalets/dribdat/issues" target="_blank">GitHub issue</a>.</i></p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "description": "Open source hackathon platform",
   "main": "index.js",
-  "repository": "git@github.com:loleg/dribdat.git",
+  "repository": "git@github.com:datalets/dribdat.git",
   "author": "Oleg Lavrovsky <oleg@datalets.ch>",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
This is the start of a proper build process with developer branches and automatic CI on PR. In other words the Dribdat project is now part of the Datalets organization, and is connected to tools for monitoring its status.

There are a couple of other changes in this release which should be of interest.

In the project footer the history of activities can be accessed by clicking on the time stamp:

![footers](https://user-images.githubusercontent.com/31819/45486301-deefd780-b75a-11e8-9b23-f0d8547a6205.jpg)

Also the way team members are displayed is now more consistent, without inline widgets. Also the JOIN button is now more prominent and the progress widget slightly refined.

The navigation at the top of the events was slightly improved, and the category navigation fixed.

![tabs](https://user-images.githubusercontent.com/31819/45486302-e0b99b00-b75a-11e8-8a64-38a4dd79abc7.jpg)

In the backend, there is now a button to Embed every event. The new project form was slightly improved, in particular with a shorter and hopefully more clearer default quickstart text.

The README has been overworked to make the project more understandable to new users.