### PR TITLE
Revamped event dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can configure your instance with the following basic environment variables:
 * `DRIBDAT_NOT_REGISTER` - set to True to disallow creating accounts on this server
 * `DRIBDAT_THEME` - can be set to one of the [Bootswatch themes](https://bootswatch.com/)
 * `DRIBDAT_CLOCK` - use 'up' or 'down' to change the position, and 'off' to hide the countdown everywhere
+* `DRIBDAT_CERT_PATH` - a URL that prefixes the download link for user certificates, followed by the SSO_ID and `.pdf` extension
 
 Support for Web analytics can be configured using one of the following variables:
 

--- a/dribdat/public/api.py
+++ b/dribdat/public/api.py
@@ -151,7 +151,7 @@ def projects_activity_json():
     recent = Activity.query.order_by(Activity.id.desc()).limit(limit).all()
     return jsonify(activities=[a.data for a in recent])
 
-# API: Outputs JSON of recent posts (a type of activity) across unique projects
+# API: Outputs JSON of recent posts (a type of activity) across projects
 @blueprint.route('/project/posts.json')
 def projects_posts_json():
     limit = request.args.get('limit') or 10

--- a/dribdat/public/api.py
+++ b/dribdat/public/api.py
@@ -129,6 +129,13 @@ def event_activity_json(event_id):
     limit = request.args.get('limit') or 50
     return jsonify(activities=get_event_activities(event_id, limit))
 
+# API: Outputs JSON of categories in the current event
+@blueprint.route('/event/current/activity.json')
+def event_activity_current_json():
+    event = Event.query.filter_by(is_current=True).first()
+    if not event: return jsonify(activities=[])
+    return event_activity_json(event.id)
+
 # API: Outputs CSV of an event activity
 @blueprint.route('/event/<int:event_id>/activity.csv')
 def event_activity_csv(event_id):
@@ -137,12 +144,21 @@ def event_activity_csv(event_id):
                     mimetype='text/csv',
                     headers={'Content-Disposition': 'attachment; filename=activity_list.csv'})
 
-# API: Outputs JSON of recent activity
+# API: Outputs JSON of recent activity across all projects
 @blueprint.route('/project/activity.json')
 def projects_activity_json():
     limit = request.args.get('limit') or 10
-    activities = [a.data for a in Activity.query.order_by(Activity.id.desc()).limit(limit).all()]
-    return jsonify(activities=activities)
+    recent = Activity.query.order_by(Activity.id.desc()).limit(limit).all()
+    return jsonify(activities=[a.data for a in recent])
+
+# API: Outputs JSON of recent posts (a type of activity) across unique projects
+@blueprint.route('/project/posts.json')
+def projects_posts_json():
+    limit = request.args.get('limit') or 10
+    recent = Activity.query.filter(Activity.action=="post")
+    recent = recent.order_by(Activity.id.desc())
+    recent = recent.limit(limit).all()
+    return jsonify(activities=[a.data for a in recent])
 
 # API: Outputs JSON of recent activity of a project
 @blueprint.route('/project/<int:project_id>/activity.json')

--- a/dribdat/public/views.py
+++ b/dribdat/public/views.py
@@ -25,7 +25,9 @@ def current_event(): return Event.query.filter_by(is_current=True).first()
 # Renders a static dashboard
 @blueprint.route("/dashboard/")
 def dashboard():
-    return render_template("public/dashboard.html", current_event=current_event())
+    event = current_event()
+    wall = 'twitter.com' in event.community_url
+    return render_template("public/dashboard.html", current_event=event, with_social_wall=wall)
 
 # Outputs JSON-LD about the current event (see also api.py/info_event_hackathon_json)
 @blueprint.route('/hackathon.json')

--- a/dribdat/settings.py
+++ b/dribdat/settings.py
@@ -12,6 +12,7 @@ class Config(object):
     SECRET_KEY = os_env.get('DRIBDAT_SECRET', 'A-big-scary-Secret-goes-HERE.')
     DRIBDAT_APIKEY = os_env.get('DRIBDAT_APIKEY', None)
     DRIBDAT_NOT_REGISTER = os_env.get('DRIBDAT_NOT_REGISTER', False)
+    DRIBDAT_CERT_PATH = os_env.get('DRIBDAT_CERT_PATH', None)
     OAUTH_ID = os_env.get('OAUTH_ID', None)
     OAUTH_TYPE = os_env.get('OAUTH_TYPE', '').lower()
     OAUTH_SECRET = os_env.get('OAUTH_SECRET', None)

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -874,19 +874,6 @@ pre { color: #333; background: white; }
 }
 .embed-view .section-header { display: none; }
 
-/* Dashboard */
-.dashboard-page #event-logo { width: 28%; }
-#schedule { color: transparent; margin-top: 1em; }
-#schedule dashboard { color: #eee; display: initial !important; }
-#schedule > * { display: none; }
-#announcements {
-    margin: 0 4em;
-    font-size: 50px;
-    font-weight: bold;
-    color: yellow;
-    background: darkblue;
-}
-
 
 /* ------------
 Code of Conduct

--- a/dribdat/templates/admin/index.html
+++ b/dribdat/templates/admin/index.html
@@ -49,7 +49,8 @@
 <script src="https://cdn.jsdelivr.net/npm/vega-lite@4"></script>
 <script src="https://cdn.jsdelivr.net/npm/vega-embed@6"></script>
 <script>
-$.getJSON('/api/project/activity.json?limit=100', function(data) {
+$.getJSON('/api/event/current/activity.json?limit=100', function(data) {
+    if (data.activities.length == 0) return $('.chart-activities').hide();
     var yourVlSpec = {
       "width": "600",
       "$schema": "https://vega.github.io/schema/vega-lite/v2.0.json",

--- a/dribdat/templates/public/about.html
+++ b/dribdat/templates/public/about.html
@@ -44,17 +44,18 @@
         <p>There is a simple API for accessing data from this site in machine-readable form. See the README for additional details.</p>
         <p>Basic data on the current frontpage event:</p>
         <ul>
-        <li><a href="/hackathon.json">/hackathon.json</a> (JSON <a href="https://schema.org/Hackathon">Schema</a>)</li>
-        <li><a href="/api/event/current/info.json">/api/event/current/info</a> (JSON)</li>
+          <li><a href="/hackathon.json">/hackathon.json</a> (JSON <a href="https://schema.org/Hackathon">Schema</a>)</li>
+          <li><a href="/api/event/current/info.json">/api/event/current/info</a> (JSON)</li>
         </ul>
         <p>Retrieve all projects from an event:</p>
         <ul>
-        <li><a href="/api/event/current/projects.json">/api/event/current/projects</a> (JSON)</li>
-        <li><a href="/api/event/current/projects.csv">/api/event/current/projects</a> (CSV)</li>
+          <li><a href="/api/event/current/projects.json">/api/event/current/projects</a> (JSON)</li>
+          <li><a href="/api/event/current/projects.csv">/api/event/current/projects</a> (CSV)</li>
         </ul>
-        <p>Recent activity (default <tt>limit</tt> = 10):</p>
+        <p>Recent activity or just posts (default <tt>limit</tt> = 10):</p>
         <ul>
-        <li><a href="/api/project/activity.json">/api/project/activity.json</a> (JSON)</li>
+          <li><a href="/api/project/activity.json">/api/project/activity.json</a> (JSON)</li>
+          <li><a href="/api/project/posts.json">/api/project/posts.json</a> (JSON)</li>
         </ul>
         <p>Search projects:</p>
         <ul>

--- a/dribdat/templates/public/dashboard.html
+++ b/dribdat/templates/public/dashboard.html
@@ -8,7 +8,8 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>DRIBDAT</title>
         <meta name="description" content="Project dashboard" />
-        <meta DISABLED-http-equiv="refresh" content="360">
+        <!-- Refresh social media wall every ten minutes -->
+        <meta http-equiv="refresh" content="600">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
         <link rel="stylesheet" href="/static/libs/font-awesome/css/font-awesome.min.css">
@@ -25,21 +26,17 @@
         <script type="text/javascript" src="/static/js/script.js"></script>
         <script type="text/javascript" src="/static/libs/FlipClock/flipclock.min.js"></script>
         <script type="text/javascript" src="/static/js/clock.js"></script>
-
-        <script src="https://cdn.jsdelivr.net/npm/vega@3"></script>
-        <script src="https://cdn.jsdelivr.net/npm/vega-lite@2"></script>
-        <script src="https://cdn.jsdelivr.net/npm/vega-embed@3"></script>
     </head>
 
     <body class="dashboard-page">
 
       <div class="container-fluid">
         <div class="row">
-          <nav class="col-md-2 bg-light sidebar">
+          <nav class="col-md-2 sidebar">
             <div class="sidebar-sticky" id="projects"></div>
-            <div class="sidebar-sticky" id="schedule">
+            <!-- <div class="sidebar-sticky" id="schedule">
               {{ current_event.description|safe }}
-            </div>
+            </div> -->
           </nav>
 
           <main role="main" class="container-countdown col-md-9 ml-sm-auto">
@@ -50,14 +47,18 @@
             {% endif %}
 
             <div class="panel-body">
-                <div id="announcements" class="editable">Hello, World!</div>
-                <div id="activities"></div>
+                <button
+                  style="position: absolute; top:0px; border:0px; background:none;"
+                  onclick="$('#announcements').show();$(this).hide()">📣</button>
+                <div id="announcements" class="editable hidden">Attention!</div>
             </div>
           </main>
 
-          <div class="col-md-3 sidebar-social">
+          <div class="col-md-3">
             {% if 'twitter.com' in current_event.community_url %}
               <a class="twitter-timeline" data-width="340" data-height="900" data-dnt="true" data-theme="dark" data-link-color="#E95F28" href="{{ current_event.community_url }}?ref_src=twsrc%5Etfw">Tweets</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            {% else %}
+              <div id="activities"></div>
             {% endif %}
           </div>
         </div>
@@ -69,6 +70,9 @@
 <style>
   body {
     overflow: hidden;
+  }
+  .hidden {
+    display: none;
   }
   #projects {
     color: #DDA;
@@ -107,6 +111,53 @@
     top: 150px;
   }
 
+  .dashboard-page #event-logo { width: 28%; }
+  #schedule { color: transparent; margin-top: 1em; }
+  #schedule dashboard { color: #eee; display: initial !important; }
+  #schedule > * { display: none; }
+
+  #announcements {
+      font-size: 50px;
+      font-weight: bold;
+      color: yellow;
+      background: darkblue;
+      opacity: 0.8;
+  }
+
+
+  #activities {
+    color: #333;
+    font: 14pt/29pt sans-serif;
+    text-align: right;
+  }
+  #activities a {
+    color: inherit;
+    text-decoration: none;
+    display: inline-block;
+    margin: 0px;
+    padding: 0px 0.5em;
+    font-size: 80%;
+    line-height: 2em;
+    text-align: right;
+    background: white;
+  }
+  #activities div {
+    background:rgba(255,255,255,0.5);
+    box-shadow: 5px 5px 5px rgba(0,0,0,0.4);
+    font-size: 80%;
+    padding: 0 0.3em;
+    margin: 1em;
+    text-align: right;
+  }
+  #activities p {
+    padding-top: 0.5em;
+    margin: 0px 0.5em;
+    line-height: 1.2em;
+    color: #000;
+    font-size: 120%;
+    text-align: left;
+  }
+
   .vega-actions-wrapper, .vega-actions { display: none; }
 
 </style>
@@ -122,37 +173,14 @@ refreshProjects = function() {
     });
   });
 
-  $.getJSON('/api/project/activity.json', function(data) {
-    var yourVlSpec = {
-      "width": 525,
-      "$schema": "https://vega.github.io/schema/vega-lite/v2.0.json",
-      "description": "Project activities",
-      "data": {
-        "values": data.activities
-      },
-      "mark": {
-        "type": "area",
-        "interpolate": "monotone"
-      },
-      "encoding": {
-        "x": {
-          "field": "date",
-          "type": "temporal",
-          "scale": { "rangeStep": null }
-        },
-        "y": {
-          "aggregate": "mean",
-          "field": "project_score",
-          "type": "quantitative",
-          "axis": { "title": null, "labels": false }
-        }
-      },
-      "config": {
-        "autosize": { "type": "fit", "contains": "padding" },
-        "axis": { "grid": false, "ticks": false }
-      }
-    }
-    vegaEmbed("#activities", yourVlSpec);
+  $.getJSON('/api/project/posts.json', function(data) {
+    $pp = $('#activities').empty();
+    data.activities.forEach(function(a) {
+      $pp.append('<div>' +
+        '<p>'+a.content+'</p>' +
+        '<a href="/project/'+a.project_id+'">@'+a.user_name + ' / ' + a.timesince + '</a>' +
+      '</div>');
+    });
   });
 
   setTimeout(refreshProjects, 60 * 1000); // refresh every minute

--- a/dribdat/templates/public/dashboard.html
+++ b/dribdat/templates/public/dashboard.html
@@ -9,7 +9,7 @@
         <title>DRIBDAT</title>
         <meta name="description" content="Project dashboard" />
         <!-- Refresh social media wall every ten minutes -->
-        {% if 'twitter.com' in current_event.community_url %}
+        {% if with_social_wall %}
           <meta http-equiv="refresh" content="600">
         {% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
@@ -41,28 +41,29 @@
             </div> -->
           </nav>
 
-          <main role="main" class="container-countdown col-md-9 ml-sm-auto">
+          <main role="main" class="container-countdown col-md-{{ '6' if with_social_wall else '9' }} ml-sm-auto">
             <img id="event-logo" src="{{ current_event.logo_url }}">
+
+            <div class="panel-body">
+                <button class="show-announcements"
+                  onclick="$('#announcements').show();$(this).hide()">📣</button>
+                <div id="announcements" class="editable hidden">Attention!</div>
+            </div>
 
             {% if current_event.countdown %}
               <div class="event-countdown" data-start="{{ current_event.countdown }}"></div>
             {% endif %}
-
-            <div class="panel-body">
-                <button
-                  style="position: absolute; top:0px; border:0px; background:none;"
-                  onclick="$('#announcements').show();$(this).hide()">📣</button>
-                <div id="announcements" class="editable hidden">Attention!</div>
-            </div>
           </main>
 
-          <div class="col-md-3">
-            {% if 'twitter.com' in current_event.community_url %}
-              <a class="twitter-timeline" data-width="340" data-height="900" data-dnt="true" data-theme="dark" data-link-color="#E95F28" href="{{ current_event.community_url }}?ref_src=twsrc%5Etfw">Tweets</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-            {% else %}
+          <div class="col-md-3" style="padding:0px">
               <div id="activities"></div>
-            {% endif %}
           </div>
+
+          {% if with_social_wall %}
+            <div class="col-md-3">
+              <a class="twitter-timeline" data-width="340" data-height="900" data-dnt="true" data-theme="dark" data-link-color="#E95F28" href="{{ current_event.community_url }}?ref_src=twsrc%5Etfw">Tweets</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            </div>
+          {% endif %}
         </div>
       </div>
   </div>
@@ -79,6 +80,7 @@
   #projects {
     color: #DDA;
     font: 14pt/29pt sans-serif;
+    overflow: hidden;
   }
   #projects a {
     color: inherit;
@@ -94,6 +96,11 @@
     padding-left: 265px;
     text-align: center;
   }
+  @media (min-width: 1000px) {
+    .container-countdown {
+      padding-left: 400px;
+    }
+  }
 
   .container-fluid .sidebar {
     height: 100%;
@@ -104,7 +111,7 @@
 
   #event-logo {
     width: 40%;
-    margin-top: 100px;
+    margin: 100px 0px;
   }
 
   #metrics {
@@ -125,7 +132,16 @@
       background: darkblue;
       opacity: 0.8;
   }
+  .show-announcements {
+    position: absolute; top:0px; border:0px; background:none; opacity: 0.5;
+  }
+  .show-announcements:hover {
+    opacity: 1;
+  }
 
+  .event-countdown {
+    position: fixed; bottom: 25px;
+  }
 
   #activities {
     color: #333;

--- a/dribdat/templates/public/dashboard.html
+++ b/dribdat/templates/public/dashboard.html
@@ -9,7 +9,9 @@
         <title>DRIBDAT</title>
         <meta name="description" content="Project dashboard" />
         <!-- Refresh social media wall every ten minutes -->
-        <meta http-equiv="refresh" content="600">
+        {% if 'twitter.com' in current_event.community_url %}
+          <meta http-equiv="refresh" content="600">
+        {% endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
         <link rel="stylesheet" href="/static/libs/font-awesome/css/font-awesome.min.css">

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -137,7 +137,9 @@
 
 <center><div role="group" aria-label="Hackathon navigation">
   {% if current_event.countdown %}
-    <a href="{{ url_for('public.home') }}" class="btn btn-sm btn-default">{{ current_event.countdown|until_date }}</a>
+    <a href="{{ url_for('public.dashboard') }}" class="btn btn-sm btn-default">
+      <i class="fa fa-id-card-o" aria-hidden="true"></i>
+      {{ current_event.countdown|until_date }}</a>
   {% endif %}
   {% if current_event.webpage_url %}
     <a href="{{ current_event.webpage_url }}" class="btn btn-sm btn-default">

--- a/dribdat/templates/public/userprofile.html
+++ b/dribdat/templates/public/userprofile.html
@@ -38,6 +38,15 @@
           <i class="fa fa-child"></i>
           Edit Profile
         </a>
+
+        {% if config.DRIBDAT_CERT_PATH %}
+        <a href="{{ config.DRIBDAT_CERT_PATH }}{{ current_user.sso_id }}"
+            download="{{ current_user.username }}_Certificate_dribdat"
+            class="btn btn-success">
+          <i class="fa fa-download"></i>
+          Download Certificate
+        </a>
+        {% endif %}
     </div>
     {% endif %}
 
@@ -50,6 +59,7 @@
     </div>
 
 </div>
+
 
 {% if user.my_story %}
 <div class="row">

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -24,7 +24,7 @@ from dribdat.database import (
     reference_col,
 )
 from dribdat.utils import (
-    format_date_range, format_date
+    format_date_range, format_date, timesince
 )
 from dribdat.onebox import format_webembed
 from dribdat.user import PROJECT_PROGRESS_PHASE
@@ -545,7 +545,9 @@ class Activity(PkModel):
             'id': self.id,
             'name': self.name,
             'time': int(mktime(self.timestamp.timetuple())),
+            'timesince': timesince(self.timestamp),
             'date': self.timestamp,
+            'content': self.content or '',
             'user_name': self.user.username,
             'user_id': self.user.id,
             'project_id': self.project.id,

--- a/dribdat/utils.py
+++ b/dribdat/utils.py
@@ -48,7 +48,7 @@ def timesince(dt, default="just now", until=False):
     )
     for period, singular, plural in periods:
         if floor(period) > 0:
-            return "%d %s %s" % (period, singular if period == 1 else plural, suffix)
+            return "%d %s %s" % (period, singular if int(period)==1 else plural, suffix)
     return default
 
 def format_date(value, format='%Y-%m-%d'):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -79,7 +79,7 @@ class TestEvent:
         assert event.name == "test"
         assert event.countdown is not None
         assert event.countdown == timezone.localize(event_dt)
-        assert timesince(event.countdown, until=True) == "1 weeks to go"
+        assert timesince(event.countdown, until=True) == "1 week to go"
 
     def test_countdown_24_days(self, db):
         now = dt.datetime.now()


### PR DESCRIPTION
The public dashboard, now semi-usable and linked at the bottom of the event page, now shows the latest posts from all projects next to the optional Twitter wall. This includes some additions to the API.

Additionally, this PR adds experimental support for downloading certificates from the user's profile page using the `DRIBDAT_CERT_PATH` setting.

![Screenshot from 2020-11-07 18-06-37](https://user-images.githubusercontent.com/31819/98965097-ee6d3580-2509-11eb-85eb-28be43b8ac61.png)
