### PR TITLE
Deeper aggregation

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -28,7 +28,7 @@ dribdat is an open source project board designed for splendid collaboration. On
 
 The name _dribdat_ is an amalgam of "Driven By Data" - with a tip of the hat to [Dribbble](https://dribbble.com/), a famous online community for graphic design which was one of the inspirations at the start of the project. We have organised a lot of hackathons over the years, and started this platform to streamline our own efforts. It is designed with the goal of helping teams - and their facilitators - sustain efforts over time, streamline information channels, and let everyone focus on driving their ideas forward. 
 
-On the front page you can see the upcoming event, as well as any previous events. A short description is followed by a link to the event home page, as well as a countdown of time remaining until the start or finish (if already started) of the event. The Projects, Challenges and Components are shown on the event home page. Here you can learn about topics, datasets, schedules, get directions and any other vital information that the organizers of the event have provided. Once the event has started, and you have formed a team, you can login and "Share project". 
+On the front page you can see the upcoming event, as well as any previous events. A short description is followed by a link to the event home page, as well as a countdown of time remaining until the start or finish (if already started) of the event. All the Projects and Challenges are shown on the event home page. Here you can learn about topics, schedules, get directions and any other vital information that the organizers of the event have provided. Once the event has started, and you have formed a team, you can login and "Share project". 
 
 ### How does it work?
 
@@ -42,7 +42,7 @@ For more user-facing guidance, see the [User's Guide](USAGE.md) and installation
 
 ### Schema
 
-One starts an **Event**, to which Challenges (= Ideas) are added. These can take the form of **Projects** (at progress level 0), or **Categories**. A team is made of up of any number of **Users** who have certain organizer-defined **Roles** and have joined a **Project**. **Components** can be added to a Project by attaching one to a **Post**.
+One starts an **Event**, to which Challenges (= Ideas) are added. These can take the form of **Projects** (at progress level 0), or **Categories**. A team is made of up of any number of **Users** who have certain organizer-defined **Roles** and have joined a **Project**. **Resources** can be added to a Project by attaching one to a **Post**.
 
 The main models are represented here:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The following options can be used to toggle **application features**:
 * `DRIBDAT_APIKEY` - for connecting clients to the remote [API](#api)
 * `DRIBDAT_USER_APPROVE` - set to True so that any new non-SSO accounts are inactive until approved by an admin
 * `DRIBDAT_NOT_REGISTER` - set to True to hide the registration, so new users can only join this server via SSO
-* `DRIBDAT_TOOL_APPROVE` - set to True for suggested components to not immediately appear
+* `DRIBDAT_TOOL_APPROVE` - set to True for suggested Resources to not immediately appear
 * `DRIBDAT_THEME` - can be set to one of the [Bootswatch themes](https://bootswatch.com/)
 * `DRIBDAT_STYLE` - provide the address to a CSS stylesheet for custom global styles
 * `DRIBDAT_CLOCK` - use 'up' or 'down' to change the position, or 'off' to hide the countdown clock

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Github Actions build](https://github.com/hackathons-ftw/dribdat/workflows/build/badge.svg)
 [![codecov](https://codecov.io/gh/hackathons-ftw/dribdat/branch/master/graph/badge.svg?token=Ccd1vTxRXg)](https://codecov.io/gh/hackathons-ftw/dribdat)
 [![Mattermost](https://img.shields.io/badge/Mattermost-chat-blue.svg)](https://team.opendata.ch/signup_user_complete/?id=74yuxwruaby9fpoukx9bmoxday)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Floleg%2Fdribdat.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Floleg%2Fdribdat?ref=badge_shield)
 
 ### A platform for time-limited, team-based, data-driven, open collaboration
 
@@ -242,3 +243,7 @@ Additional and :heart:-felt thanks for testing and feedback to:
 - [@khashashin](https://github.com/khashashin)
 - [@philshem](https://github.com/philshem)
 - [Thomas Amberg](https://github.com/tamberg)
+
+
+## License
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Floleg%2Fdribdat.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Floleg%2Fdribdat?ref=badge_large)

--- a/dribdat/admin/forms.py
+++ b/dribdat/admin/forms.py
@@ -42,7 +42,7 @@ class EventForm(FlaskForm):
     hostname = StringField(u'Hosted by', [length(max=80)])
     location = StringField(u'Located at', [length(max=255)])
     description = TextAreaField(u'Description', description=u'Markdown and HTML supported')
-    instruction = TextAreaField(u'Instructions for participants, event page', description=u'Markdown and HTML supported')
+    instruction = TextAreaField(u'Instructions for authenticated participants', description=u'Event and Components page, Markdown and HTML supported')
     logo_url = URLField(u'Host logo link', [length(max=255)])
     webpage_url = URLField(u'Home page link', [length(max=255)])
     community_url = URLField(u'Community link', [length(max=255)])

--- a/dribdat/admin/forms.py
+++ b/dribdat/admin/forms.py
@@ -42,7 +42,7 @@ class EventForm(FlaskForm):
     hostname = StringField(u'Hosted by', [length(max=80)])
     location = StringField(u'Located at', [length(max=255)])
     description = TextAreaField(u'Description', description=u'Markdown and HTML supported')
-    instruction = TextAreaField(u'Instructions for authenticated participants', description=u'Event and Components page, Markdown and HTML supported')
+    instruction = TextAreaField(u'Instructions for authenticated participants', description=u'Event and Resources page, Markdown and HTML supported')
     logo_url = URLField(u'Host logo link', [length(max=255)])
     webpage_url = URLField(u'Home page link', [length(max=255)])
     community_url = URLField(u'Community link', [length(max=255)])

--- a/dribdat/aggregation.py
+++ b/dribdat/aggregation.py
@@ -86,7 +86,7 @@ def SuggestionsByProgress(progress=None, event=None):
     resources = resources.filter_by(is_visible=True)
     return resources.order_by(Resource.type_id).all()
 
-def SuggestionsTreeForEvent(event):
+def SuggestionsTreeForEvent(event=None):
     """ Collect resources by progress """
     allres = SuggestionsByProgress(None, event)
     steps = []
@@ -94,15 +94,16 @@ def SuggestionsTreeForEvent(event):
     for ix, p in enumerate(projectProgressList(True, False)):
         rrr = []
         for r in allres:
-            if r.progress_tip and r.progress_tip == p[0]: rrr.append(r)
+            if r.progress_tip is not None and r.progress_tip == p[0]:
+                rrr.append(r)
+                shown.append(r.id)
         steps.append({
             'index': ix + 1, 'name': p[1], 'resources': rrr
         })
-        shown.extend(rrr)
     # show progress-less resources
     rr0 = []
     for r in allres:
-        if not r.progress_tip or not r in shown: rr0.append(r)
+        if r.progress_tip is None or not r.id in shown: rr0.append(r)
     if len(rr0) > 0:
         steps.append({
             'name': '/etc', 'index': -1, 'resources': rr0

--- a/dribdat/apievents.py
+++ b/dribdat/apievents.py
@@ -32,7 +32,7 @@ def FetchGithubCommits(full_name, since=None, until=None):
             author = commit['committer']['name'][:100]
         url = "https://github.com/%s" % full_name
         if 'html_url' in entry:
-            url = entry['url']
+            url = entry['html_url']
         commitlog.append({
             'url': url,
             'date': datestamp,

--- a/dribdat/apievents.py
+++ b/dribdat/apievents.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+""" Collecting events from remote repositories """
+
+import logging
+import requests
+import datetime as dt
+from dateutil import parser
+
+def FetchGithubCommits(full_name, since=None, until=None):
+    apiurl = "https://api.github.com/repos/%s/commits?per_page=50" % full_name
+    if since is not None:
+        apiurl += "&since=%s" % since.replace(microsecond=0).isoformat()
+    if until is not None:
+        apiurl += "&until=%s" % until.replace(microsecond=0).isoformat()
+    data = requests.get(apiurl)
+    if data.status_code != 200:
+        print(data)
+        logging.warn("Could not sync GitHub commits on %s" % full_name)
+        return []
+    json = data.json()
+    if 'message' in json:
+        logging.warn("Could not sync GitHub commits on %s: %s" % (full_name, json['message']))
+        return []
+    commitlog = []
+    for entry in json:
+        if not 'commit' in entry: continue
+        commit = entry['commit']
+        datestamp = parser.parse(commit['committer']['date'])
+        if 'author' in entry and 'login' in entry['author']:
+            author = entry['author']['login']
+        else:
+            author = commit['committer']['name'][:100]
+        url = "https://github.com/%s" % full_name
+        if 'html_url' in entry:
+            url = entry['url']
+        commitlog.append({
+            'url': url,
+            'date': datestamp,
+            'author': author,
+            'message': commit['message'][:256],
+        })
+    return commitlog

--- a/dribdat/apievents.py
+++ b/dribdat/apievents.py
@@ -26,7 +26,7 @@ def FetchGithubCommits(full_name, since=None, until=None):
         if not 'commit' in entry: continue
         commit = entry['commit']
         datestamp = parser.parse(commit['committer']['date'])
-        if 'author' in entry and 'login' in entry['author']:
+        if 'author' in entry and entry['author'] is not None and 'login' in entry['author']:
             author = entry['author']['login']
         else:
             author = commit['committer']['name'][:100]

--- a/dribdat/public/api.py
+++ b/dribdat/public/api.py
@@ -72,15 +72,25 @@ def info_event_hackathon_json(event_id):
 def get_projects_by_event(event_id):
     return Project.query.filter_by(event_id=event_id, is_hidden=False)
 
-def get_project_summaries(projects):
-    summaries = expand_project_urls([ p.data for p in projects ])
+def get_project_summaries(projects, is_moar=False):
+    if is_moar:
+        summaries = []
+        for project in projects:
+            p = project.data
+            p['autotext'] = project.autotext # Markdown
+            p['longtext'] = project.longtext # Markdown - see longhtml()
+            summaries.append(p)
+    else:
+        summaries = [ p.data for p in projects ]
+    summaries = expand_project_urls(summaries)
     summaries.sort(key=lambda x: x['score'], reverse=True)
     return summaries
 
 # Collect all projects and challenges for an event
 def project_list(event_id):
+    is_moar = bool(request.args.get('moar', type=bool)) or False
     projects = get_projects_by_event(event_id)
-    return get_project_summaries(projects)
+    return get_project_summaries(projects, is_moar)
 
 # API: Outputs JSON of projects in the current event, along with its info
 @blueprint.route('/event/current/projects.json')

--- a/dribdat/public/forms.py
+++ b/dribdat/public/forms.py
@@ -103,7 +103,7 @@ class ProjectPost(FlaskForm):
     note = TextAreaField(u'Note', [length(max=140), DataRequired()],
         description=u'What are you working on right now?')
     progress = SelectField(u'Progress', coerce=int)
-    resource = SelectField(u'Components', coerce=int,
+    resource = SelectField(u'Resources', coerce=int,
         description=u'Are you using one of these?')
     submit = SubmitField(u'Save post')
 

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -535,7 +535,7 @@ nav .navbar-nav .nav-item {
   display: inline-block;
   text-align: center;
   font-size: 140%;
-  width: 5em;
+  width: 6em;
   background: rgba(255, 255, 255, 0.5);
 }
 .project-buttons .btn:hover {

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -637,7 +637,7 @@ nav .navbar-nav .nav-item {
   background: url(https://raw.githubusercontent.com/RickStrahl/jquery-resizable/master/assets/wingrip.png) no-repeat;
  }
 
-/* Components */
+/* Resources */
 .resource-card {
   display: inline-block;
   background: rgba(0,0,0,0.06);

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -942,7 +942,6 @@ pre { color: #333; background: white; }
 /* tip section used in resources and elsewhere */
 
 .join-tip {
-  margin-top: 1em;
   padding: 0.5em;
   font-size: 115%;
   text-align: center;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -943,7 +943,6 @@ pre { color: #333; background: white; }
 
 .join-tip {
   padding: 0.5em;
-  font-size: 115%;
   text-align: center;
 }
 

--- a/dribdat/static/css/timeline.css
+++ b/dribdat/static/css/timeline.css
@@ -115,8 +115,8 @@
     padding: 0 5px 10px 5px;
   }
 
-.timeline-item {
-  cursor: pointer; }
+/* .timeline-item {
+  cursor: pointer; } */
   .timeline-item .timeline-img-header {
     /* background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, .4)), url('https://picsum.photos/1000/800/?random') center center no-repeat; */
     background-size: cover; }

--- a/dribdat/static/css/timeline.css
+++ b/dribdat/static/css/timeline.css
@@ -120,6 +120,8 @@
   .timeline-item .timeline-img-header {
     /* background: linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, .4)), url('https://picsum.photos/1000/800/?random') center center no-repeat; */
     background-size: cover; }
+  .timeline-item .timeline-img-header a {
+    text-decoration: none; }
 
 .timeline-img-header {
   height: auto;

--- a/dribdat/static/css/timeline.css
+++ b/dribdat/static/css/timeline.css
@@ -30,10 +30,10 @@
 	} */ }
   .timeline::before {
     content: '';
-    background: #888;
+    background: #baa;
     top: 0;
-    width: 5px;
-    height: 95%;
+    width: 6px;
+    height: 100%;
     position: absolute;
     left: 50%;
     transform: translateX(-50%); }
@@ -89,6 +89,7 @@
   width: 30px;
   height: 30px;
   background: #888;
+  opacity: 0.6;
   border-radius: 50%;
   position: absolute;
   left: 50%;

--- a/dribdat/static/js/script.js
+++ b/dribdat/static/js/script.js
@@ -208,7 +208,7 @@
     }
   });
   // Toggle challenges after the hackathon
-  $('.event-finished .nav-categories #challenges').parent().click();
+  // $('.event-finished .nav-categories #challenges').parent().click();
 
   // Roll up categories if there is only one, and no projects
   if ($navCategories.length === 1)

--- a/dribdat/templates/admin/layout.html
+++ b/dribdat/templates/admin/layout.html
@@ -6,7 +6,7 @@
 {% set tabs = [
     ("events", url_for('admin.events')),
     ("presets", url_for('admin.presets')),
-    ("components", url_for('admin.resources')),
+    ("resources", url_for('admin.resources')),
     ("projects", url_for('admin.projects')),
     ("users", url_for('admin.users')),
 ]%}

--- a/dribdat/templates/admin/resources.html
+++ b/dribdat/templates/admin/resources.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container">
     <a href="{{ url_for('admin.resource_new') }}" class="btn btn-success btn-lg">Add resource</a>
-    <h2>Components</h2>
+    <h2>Resources</h2>
     <table class='table table-bordered table-hover'>
         <thead>
             <tr>

--- a/dribdat/templates/includes/nav.html
+++ b/dribdat/templates/includes/nav.html
@@ -31,7 +31,7 @@
           <li class="nav-item">
             <a class="nav-link {% if active == 'resources' %}active{% endif %}" href="{{ url_for('public.event_resources', event_id=event.id) }}">
               <i class="fa fa-cube"></i>
-              Components
+              Resources
             </a>
           </li>
           <li class="nav-item">

--- a/dribdat/templates/includes/stages.csv
+++ b/dribdat/templates/includes/stages.csv
@@ -1,6 +1,6 @@
 id;name;phase;description
--1;CHALLENGE;Challenge;🚧 This is an idea or challenge description
-0;NEW;Researching;👪 A team has formed and started a project
+0;CHALLENGE;Challenge;🚧 This is an idea or challenge description
+5;NEW;Researching;👪 A team has formed and started a project
 10;RESEARCHED;Sketching;⚗️ Research has been done to define the scope
 20;SKETCHED;Prototyping;🎨 Initial designs have been sketched and shared
 30;PROTOTYPED;Launching;🐣 A prototype of the idea has been developed

--- a/dribdat/templates/public/about.html
+++ b/dribdat/templates/public/about.html
@@ -42,6 +42,7 @@
         <ul>
           <li><a href="/api/event/current/projects.json">/api/event/current/projects</a> (JSON)</li>
           <li><a href="/api/event/current/projects.csv">/api/event/current/projects</a> (CSV)</li>
+          <li><a href="/api/event/current/projects.csv?moar=1">/api/event/current/projects</a>? (CSV or JSON with full texts)</li>
         </ul>
         <p>Recent activity or just posts (default <tt>limit</tt> = 10):</p>
         <ul>

--- a/dribdat/templates/public/dribs.html
+++ b/dribdat/templates/public/dribs.html
@@ -10,6 +10,11 @@
 <div class="jumbotron">
   <div class="container">
 
+    {% if not data.items %}
+      <div class="nothing-here">
+        Log in and write a <b>Post</b> to see your project updates here!
+      </div>
+    {% else %}
     <section class="timeline">
       {% for s in data.items %}
       <div class="timeline-item">
@@ -39,7 +44,8 @@
       </div>
       {% endfor %}
     </section>
-
+    {% endif %}
+    
     {% if data.has_next %}
       <a href="{{ url_for(endpoint, page=data.next_num) }}"
         title="Load another page of dribs" style="width:100%"

--- a/dribdat/templates/public/dribs.html
+++ b/dribdat/templates/public/dribs.html
@@ -20,12 +20,12 @@
       <div class="timeline-item">
         <div class="timeline-img"></div>
         <div class="timeline-content timeline-card js--fadeInBottom">
-          <a href="{{ url_for('public.project', project_id=s.project.id)}}">
-            <div class="timeline-img-header">
+          <div class="timeline-img-header">
+            <a href="{{ url_for('public.project', project_id=s.project.id)}}">
               <h2>{{s.project.name}}</h2>
-            </div>
-          </a>
-          
+            </a>
+          </div>
+
           {% if s.content %}
             <div class="content">
               {{s.content|markdown|safe}}

--- a/dribdat/templates/public/dribs.html
+++ b/dribdat/templates/public/dribs.html
@@ -25,13 +25,24 @@
               <h2>{{s.project.name}}</h2>
             </div>
           </a>
+          
           {% if s.content %}
-            {{s.content|markdown|safe}}
+            <div class="content">
+              {{s.content|markdown|safe}}
+            </div>
           {% endif %}
-          <div class="date">
-            {{s.timestamp|format_datetime}}
-            {% if s.user %} ~ <b>{{ s.user.username }}</b>{% endif %}
-          </div>
+
+          {% if s.ref_url %}
+            <a href="{{ s.ref_url }}" target="_blank">
+          {% endif %}
+            <div class="date">
+              {{s.timestamp|format_datetime}}
+              {% if s.user %} ~ <b>{{ s.user.username }}</b>{% endif %}
+            </div>
+          {% if s.ref_url %}
+            </a>
+          {% endif %}
+
           {% if s.resource and s.resource.is_visible %}
             <a class="resource-card" href="{{ url_for('public.resource', resource_id=s.resource.id) }}">
               <i title="{{s.resource.of_type}}"
@@ -45,7 +56,7 @@
       {% endfor %}
     </section>
     {% endif %}
-    
+
     {% if data.has_next %}
       <a href="{{ url_for(endpoint, page=data.next_num) }}"
         title="Load another page of dribs" style="width:100%"

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -86,9 +86,11 @@
 
 <div class="category-info">
   {% if current_event.has_started and not current_event.has_finished %}
+    {% if not current_user or not current_user.active %}
     <div category-id="infobox" class="category-container category-tip">
-      <center><h4><i class="fa fa-lightbulb-o"></i> &nbsp;The event has started! Explore challenges and join projects above.</h4></center>
+      <center><h4><i class="fa fa-lightbulb-o"></i> &nbsp;The event has started! Explore the challenges above, then log in to get resources and join projects.</h4></center>
     </div>
+    {% endif %}
   {% endif %}
   {% for category in current_event.categories_for_event() %}
   <div category-id="{{category.id}}" class="category-container" style="border-top:5px solid {{category.logo_color}}; display:none">
@@ -127,7 +129,7 @@
   </div>
 {% endif %}
 
-{% if current_event.instruction %}
+{% if current_user and current_user.active and current_event.instruction %}
   <a name="instruction"></a>
   <div class="jumbotron event-instruction">
     <div class="content">

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -123,7 +123,7 @@
       </a>
       <a href="{{ url_for('public.event_resources', event_id=current_event.id) }}" class="btn btn-lg btn-info">
         <i class="fa fa-cube" aria-hidden="true"></i>
-        <span>Components</span>
+        <span>Resources</span>
       </a>
     {% endif %}
   </div>
@@ -181,7 +181,7 @@
       Share</a>
     <a href="{{ url_for('public.event_resources', event_id=current_event.id) }}" class="btn btn-default btn-sm">
       <i class="fa fa-cube" aria-hidden="true"></i>
-      <span>Components</span>
+      <span>Resources</span>
     </a>
     <a href="{{ url_for('public.event_participants', event_id=current_event.id) }}" class="btn btn-default btn-sm">
       <i class="fa fa-user" aria-hidden="true"></i>

--- a/dribdat/templates/public/home.html
+++ b/dribdat/templates/public/home.html
@@ -47,10 +47,10 @@
           {% if current_event.has_finished %}
           View the Results
           {% elif current_event.has_started %}
-          Explore Challenges
+          Get started!
           {% else %}
           <!-- Event not yet started -->
-          Post Challenge
+          Challenges
           {% endif %}
         </b></a>
         {% if current_event.has_started and current_event.can_start_project %}

--- a/dribdat/templates/public/home.html
+++ b/dribdat/templates/public/home.html
@@ -118,7 +118,7 @@
                 Information</a>
             {% endif %}
             <a href="{{ url_for('public.event_resources', event_id=event.id) }}" class="btn btn-secondary">
-              Components</a>
+              Resources</a>
             <a href="{{ url_for('public.event', event_id=event.id) }}" class="btn btn-warning">
               Challenges
             </a>

--- a/dribdat/templates/public/home.html
+++ b/dribdat/templates/public/home.html
@@ -109,7 +109,7 @@
               <span>{{ event.location }}</span>
             </p>
             <p class="an-event-description">
-              {{event.description|markdown}}
+              {{event.description|markdown|striptags|truncate(500)}}
             </p>
           </div>
           <div class="btn-group an-event-actions" role="group">
@@ -153,7 +153,7 @@
               <span>{{ event.location }}</span>
             </p>
             <p class="an-event-description">
-              {{event.description|markdown}}
+              {{event.description|markdown|striptags|truncate(500)}}
             </p>
           </div>
           <div class="btn-group an-event-actions" role="group">

--- a/dribdat/templates/public/project.html
+++ b/dribdat/templates/public/project.html
@@ -240,13 +240,22 @@
             <h2>{{s.title}}</h2>
           </div>
           {% endif %}
+
           {% if s.text %}
-            {{s.text|markdown|safe}}
+            <div class="content">
+              {{s.text|markdown|safe}}
+            </div>
           {% endif %}
 
           <div class="date">
-            {{s.date|format_datetime}}
-            {% if s.author %} ~ <b>{{ s.author }}</b>{% endif %}
+          {% if s.ref_url %}
+            <a href="{{ s.ref_url }}" target="_blank">
+          {% endif %}
+              {{s.date|format_datetime}}
+              {% if s.author %} ~ <b>{{ s.author }}</b>{% endif %}
+          {% if s.ref_url %}
+            </a>
+          {% endif %}
           </div>
 
           {% if s.resource and s.resource.is_visible %}

--- a/dribdat/templates/public/project.html
+++ b/dribdat/templates/public/project.html
@@ -113,7 +113,7 @@
   {% if not project.is_challenge and project_starred and suggestions %}
     <div class="alert alert-info resource-list col-12">
       <a class="close" title="Close" href="#" data-dismiss="alert">&times;</a>
-        <p>For this stage of your project, we suggest:</p>
+        <p>Suggestions for this stage of your project:</p>
     {% for resource in suggestions %}
         {% if resource.is_visible %}
         <a class="col-5 resource-card" href="{{ url_for('public.resource', resource_id=resource.id) }}">

--- a/dribdat/templates/public/projectpost.html
+++ b/dribdat/templates/public/projectpost.html
@@ -13,7 +13,7 @@
 
     {{ render_form(url_for('public.project_post', project_id=project.id), form) }}
 
-    <p class="text-center mt-3 bigger"><b>&#128161; Tip</b>: you can suggest further
-      <a href="{{ url_for('public.resource_post') }}" target="_blank">resources here</a>.</p>
+    <p class="text-center mt-3 bigger"><b>&#128161;</b> You can suggest
+      <a href="{{ url_for('public.resource_post') }}" target="_blank">more resources</a> here.</p>
   </div>
 {% endblock %}

--- a/dribdat/templates/public/resource.html
+++ b/dribdat/templates/public/resource.html
@@ -2,7 +2,7 @@
 
 {% extends "layout.html" %}
 
-{% block page_title %}{{resource.name}} / Components{% endblock %}
+{% block page_title %}{{resource.name}} / Resources{% endblock %}
 {% block body_class %}resource-page{% endblock %}
 
 {% block content %}
@@ -93,7 +93,7 @@
 <center class="mt-5">
     <a class="btn btn-info btn-lg" href="{{ url_for('public.event_resources', event_id=current_event.id) }}">
         <i class="fa fa-cube" aria-hidden="true"></i>
-        <span>Components</span>
+        <span>Resources</span>
     </a>
     <a class="btn btn-dark btn-lg" href="{{ url_for('public.event', event_id=current_event.id) }}">
         <i class="fa fa-arrow-left" aria-hidden="true"></i>

--- a/dribdat/templates/public/resourceedit.html
+++ b/dribdat/templates/public/resourceedit.html
@@ -2,7 +2,7 @@
 
 {% extends "layout.html" %}
 
-{% block page_title %}Components edit{% endblock %}
+{% block page_title %}Resources edit{% endblock %}
 {% block body_class %}projectform{% endblock %}
 
 {% block content %}

--- a/dribdat/templates/public/resources.html
+++ b/dribdat/templates/public/resources.html
@@ -7,15 +7,7 @@
 {% block content %}
 <h1 class="huge">Resources</h1>
 
-  <div class="container join-tip" style="text-align:right">
-    <i class="fa fa-cloud"></i> Tool
-    <i class="fa fa-gear"></i> Code
-    <i class="fa fa-cube"></i> Data &amp;
-    <i class="fa fa-leaf"></i> Other suggestions by project stage.
-  </div>
-
 <div class="jumbotron">
-
 
   <div class="container">
 
@@ -45,7 +37,18 @@
       </div>
     {% endfor %}
 
-    <center class="mt-5">
+    <div class="join-tip bigger mt-4">
+      <i class="fa fa-cloud"></i> Tool
+      <i class="fa fa-gear"></i> Code
+      <i class="fa fa-cube"></i> Data &amp;
+      <i class="fa fa-leaf"></i> Other tips by project stage.
+    </div>
+
+    <div class="join-tip">
+      <b>&#128161; Join</b> a project and use the <b>Post</b> button to progress through stages.
+    </div>
+
+    <center class="mt-3">
       <a class="btn btn-success btn-lg" href="{{ url_for('public.resource_post') }}">Suggest another resource</a>
     </center>
   </div>
@@ -62,10 +65,6 @@
       </div>
     </div>
   {% endif %}
-
-  <div class="container join-tip bigger">
-    <b>Join</b> a project and use the <a href="#" class="btn btn-success disabled btn-sm">Post</a> button to progress through stages.
-  </div>
 
   <center class="mt-5">
     <a class="btn btn-dark btn-lg" href="{{ url_for('public.event', event_id=current_event.id) }}">

--- a/dribdat/templates/public/resources.html
+++ b/dribdat/templates/public/resources.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 
-{% block page_title %}Components{% endblock %}
+{% block page_title %}Resources{% endblock %}
 
 {% block body_class %}resources-page{% endblock %}
 
 {% block content %}
-<h1 class="huge">Components</h1>
+<h1 class="huge">Resources</h1>
 
   <div class="container join-tip" style="text-align:right">
     <i class="fa fa-cloud"></i> Tool

--- a/dribdat/templates/public/resources.html
+++ b/dribdat/templates/public/resources.html
@@ -7,7 +7,16 @@
 {% block content %}
 <h1 class="huge">Components</h1>
 
+  <div class="container join-tip" style="text-align:right">
+    <i class="fa fa-cloud"></i> Tool
+    <i class="fa fa-gear"></i> Code
+    <i class="fa fa-cube"></i> Data &amp;
+    <i class="fa fa-leaf"></i> Other suggestions by project stage.
+  </div>
+
 <div class="jumbotron">
+
+
   <div class="container">
 
     <a name="steps"></a>
@@ -42,21 +51,27 @@
   </div>
 </div>
 
-<div class="container join-tip"><p>
-  <i class="fa fa-cloud"></i> Tool
-  <i class="fa fa-gear"></i> Code
-  <i class="fa fa-cube"></i> Data &amp;
-  <i class="fa fa-leaf"></i> Other recommended components can be found here, sorted by stage.
-</p><p class="bigger">
-  <b>Join</b> a project and use the <a href="#" class="btn btn-success disabled btn-sm">Post</a> button to progress through stages.
-</p></div>
-
 {% if current_event %}
-<center class="mt-5">
+
+  {% if current_user and current_user.active and current_event.instruction %}
+    <a name="instruction"></a>
+    <h2>Instructions</h2>
+    <div class="jumbotron event-instruction mt-3">
+      <div class="content">
+        {{current_event.instruction|markdown}}
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="container join-tip bigger">
+    <b>Join</b> a project and use the <a href="#" class="btn btn-success disabled btn-sm">Post</a> button to progress through stages.
+  </div>
+
+  <center class="mt-5">
     <a class="btn btn-dark btn-lg" href="{{ url_for('public.event', event_id=current_event.id) }}">
       <i class="fa fa-arrow-left" aria-hidden="true"></i>
       Back to the future</a>
-</center>
+  </center>
 {% endif %}
 
 {% endblock %}

--- a/dribdat/templates/public/userprofile.html
+++ b/dribdat/templates/public/userprofile.html
@@ -130,7 +130,7 @@
 
 {% if submissions %}
 <div class="container">
-    <h5 class="mt-5 text-center">Components</h5>
+    <h5 class="mt-5 text-center">Resources</h5>
     <div class="resource-list row">
     {% for resource in submissions %}
         {% if resource.is_visible %}

--- a/dribdat/templates/public/userprofile.html
+++ b/dribdat/templates/public/userprofile.html
@@ -162,16 +162,22 @@
 <section class="timeline">
 {% for s in posts %}
 <div class="timeline-item">
-    <a href="{{ url_for('public.project', project_id=s.project_id) }}">
-        <div class="timeline-img"></div>
-        <div class="timeline-content timeline-card js--fadeInBottom">
-          <div class="date">{{s.date|format_datetime}}</div>
-          <div class="timeline-img-header">
-            <h2>{{s.project_name}}</h2>
-          </div>
+    <div class="timeline-img"></div>
+    <div class="timeline-content timeline-card js--fadeInBottom">
+      <div class="timeline-img-header">
+        <a href="{{ url_for('public.project', project_id=s.project_id) }}">
+          <h2>{{s.project_name}}</h2>
+        </a>
+      </div>
+
+      {% if s.content %}
+        <div class="content">
           {{s.content|markdown|safe}}
         </div>
-    </a>
+      {% endif %}
+
+      <div class="date">{{s.date|format_datetime}}</div>
+    </div>
 </div>
 {% endfor %}
 </section>

--- a/dribdat/user/constants.py
+++ b/dribdat/user/constants.py
@@ -43,7 +43,7 @@ RESOURCE_TYPES = {
 
 # Project progress stages
 project_stages = load_csv_presets('stages', 'name')
-PR_CHALLENGE = project_stages['CHALLENGE']['id']
+PR_CHALLENGE = int(project_stages['CHALLENGE']['id'])
 PROJECT_PROGRESS = {}
 PROJECT_PROGRESS_PHASE = {}
 for ps in project_stages:

--- a/dribdat/user/constants.py
+++ b/dribdat/user/constants.py
@@ -70,8 +70,10 @@ def projectProgressList(All=True, WithEmpty=True):
     return sorted(pl, key=lambda x: x[0])
 
 def getProjectPhase(project):
-    if project is None or project.progress is None: return ""
-    if not project.progress in PROJECT_PROGRESS_PHASE: return ""
+    if project is None or project.progress is None:
+        return ""
+    if not project.progress in PROJECT_PROGRESS_PHASE:
+        return PROJECT_PROGRESS_PHASE[PR_CHALLENGE]
     return PROJECT_PROGRESS_PHASE[project.progress]
 
 def isUserActive(user):

--- a/dribdat/user/constants.py
+++ b/dribdat/user/constants.py
@@ -22,7 +22,8 @@ USER_STATUS = {
 RESOURCE_CODES = {
     'data': 100,
     'code': 200,
-    'tool': 300
+    'tool': 300,
+    'other': 0
 }
 RESOURCE_TYPES = {
     RESOURCE_CODES['data']: "Data",
@@ -37,6 +38,7 @@ RESOURCE_TYPES = {
     # 'tool/kanban': "Project planner",
     # 'tool/sim': "Simulation tool",
     # 'tool/ux': "Wireframing app",
+    RESOURCE_CODES['other']: "Other",
 }
 
 # Project progress stages
@@ -55,6 +57,7 @@ def resourceTypeList():
 
 def getResourceType(resource):
     if resource is None: return ""
+    if resource.type_id is None: return RESOURCE_TYPES[0]
     if not resource.type_id in RESOURCE_TYPES: return ""
     return RESOURCE_TYPES[resource.type_id]
 

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -652,7 +652,7 @@ class Resource(PkModel):
 
     def get_comments(self, max=5):
         return Activity.query.filter_by(resource_id=self.id)\
-            .distinct(Activity.resource_id).group_by(Activity.resource_id)\
+            .group_by(Activity.resource_id)\
             .order_by(Activity.id.desc()).limit(max)
     def count_mentions(self):
         return Activity.query.filter_by(resource_id=self.id)\

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -652,8 +652,7 @@ class Resource(PkModel):
 
     def get_comments(self, max=5):
         return Activity.query.filter_by(resource_id=self.id)\
-            .group_by(Activity.resource_id)\
-            .order_by(Activity.id.desc()).limit(max)
+            .group_by(Activity.resource_id).limit(max)
     def count_mentions(self):
         return Activity.query.filter_by(resource_id=self.id)\
             .group_by(Activity.id).count()

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -713,7 +713,7 @@ class Activity(PkModel):
 
     @property
     def data(self):
-        return {
+        a = {
             'id': self.id,
             'name': self.name,
             'time': int(mktime(self.timestamp.timetuple())),
@@ -721,15 +721,19 @@ class Activity(PkModel):
             'date': self.timestamp,
             'content': self.content or '',
             'ref_url': self.ref_url or '',
-            'user_name': self.user.username,
-            'user_id': self.user.id,
-            'project_id': self.project.id,
-            'project_name': self.project.name,
-            'project_score': self.project_score or 0,
-            'project_phase': getProjectPhase(self.project),
-            'resource_id': self.resource_id,
-            'resource_type': getResourceType(self.resource),
         }
+        if self.user:
+            a['user_id'] = self.user.id
+            a['user_name'] = self.user.username
+        if self.project:
+            a['project_id'] = self.project.id
+            a['project_name'] = self.project.name
+            a['project_score'] = self.project_score or 0
+            a['project_phase'] = getProjectPhase(self.project)
+        if self.resource:
+            a['resource_id'] = self.resource_id
+            a['resource_type'] = getResourceType(self.resource)
+        return a
 
     def __init__(self, name, project_id, **kwargs):
         if name:

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -269,6 +269,14 @@ class Event(PkModel):
         return not self.has_finished and not self.lock_starting
 
     @property
+    def ends_at_tz(self):
+        tz = pytz.timezone(current_app.config['TIME_ZONE'])
+        return tz.localize(self.ends_at)
+    @property
+    def starts_at_tz(self):
+        tz = pytz.timezone(current_app.config['TIME_ZONE'])
+        return tz.localize(self.starts_at)
+    @property
     def countdown(self):
         # Normalizing dates & timezones.
         tz = pytz.timezone(current_app.config['TIME_ZONE'])
@@ -386,6 +394,7 @@ class Project(PkModel):
             if a.action == 'sync':
                 title = "Synchronized"
                 text = "Readme fetched from source"
+                continue
             elif a.action == 'post' and a.content is not None:
                 title = ""
                 text = a.content
@@ -393,6 +402,10 @@ class Project(PkModel):
                 title = "Team forming"
                 text = a.user.username + " has joined!"
                 author = ""
+            elif a.name == 'update' and a.action == 'commit':
+                title = "Code commit"
+                text = a.content
+                author = a.user.username
             elif a.name == 'update':
                 title = ""
                 text = "Worked on documentation"
@@ -674,6 +687,7 @@ class Activity(PkModel):
         name="activity_type"))
     action = Column(db.String(32), nullable=True)
         # 'external',
+        # 'commit',
         # 'boost',
         # 'sync',
         # 'post',

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -652,7 +652,7 @@ class Resource(PkModel):
 
     def get_comments(self, max=5):
         return Activity.query.filter_by(resource_id=self.id)\
-            .group_by(Activity.resource_id).limit(max)
+            .distinct(Activity.resource_id).limit(max)
     def count_mentions(self):
         return Activity.query.filter_by(resource_id=self.id)\
             .group_by(Activity.id).count()

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -614,7 +614,7 @@ class Resource(PkModel):
     name = Column(db.String(80), unique=True, nullable=False)
     type_id = Column(db.Integer(), nullable=True)
     created_at = Column(db.DateTime, nullable=False, default=dt.datetime.utcnow)
-    is_visible = Column(db.Boolean(), default=False)
+    is_visible = Column(db.Boolean(), default=True)
     progress_tip = Column(db.Integer(), nullable=True)
     source_url = Column(db.String(2048), nullable=True)
     download_url = Column(db.String(2048), nullable=True)

--- a/migrations/versions/1ba5ea3134a7_.py
+++ b/migrations/versions/1ba5ea3134a7_.py
@@ -27,8 +27,9 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_constraint(None, 'resources', type_='foreignkey')
-    op.drop_column('resources', 'event_id')
+    with op.batch_alter_table('resources') as batch_op:
+        batch_op.drop_column('event_id')
+        batch_op.drop_constraint('resources', type_='foreignkey')
     with op.batch_alter_table('events') as batch_op:
         batch_op.alter_column(
             'instruction', new_column_name='resources'

--- a/migrations/versions/30e6fbf01833_.py
+++ b/migrations/versions/30e6fbf01833_.py
@@ -1,0 +1,30 @@
+"""empty message
+
+Revision ID: 30e6fbf01833
+Revises: 1ba5ea3134a7
+Create Date: 2021-05-25 22:45:17.387052
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '30e6fbf01833'
+down_revision = '1ba5ea3134a7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('activities') as batch_op:
+        batch_op.add_column(sa.Column('ref_url', sa.String(length=2048), nullable=True))
+        batch_op.alter_column('user_id', nullable=True)
+        batch_op.alter_column('project_id', nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('activities') as batch_op:
+        batch_op.alter_column('user_id', nullable=False)
+        batch_op.alter_column('project_id', nullable=False)
+        batch_op.drop_column('ref_url')

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ description = "A database migration tool for SQLAlchemy."
 name = "alembic"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-version = "1.6.2"
+version = "1.6.3"
 
 [package.dependencies]
 Mako = "*"
@@ -103,10 +103,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.17.73"
+version = "1.17.78"
 
 [package.dependencies]
-botocore = ">=1.20.73,<1.21.0"
+botocore = ">=1.20.78,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.4.0,<0.5.0"
 
@@ -116,7 +116,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.20.73"
+version = "1.20.78"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
@@ -159,10 +159,14 @@ description = "Composable command line interface toolkit"
 name = "click"
 optional = false
 python-versions = ">=3.6"
-version = "8.0.0"
+version = "8.0.1"
 
 [package.dependencies]
 colorama = "*"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
 category = "main"
@@ -286,7 +290,7 @@ description = "Faker is a Python package that generates fake data for you."
 name = "faker"
 optional = false
 python-versions = ">=3.6"
-version = "8.1.4"
+version = "8.2.1"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
@@ -389,7 +393,7 @@ description = "A simple framework for building complex web applications."
 name = "flask"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.0"
+version = "2.0.1"
 
 [package.dependencies]
 Jinja2 = ">=3.0"
@@ -705,7 +709,7 @@ description = "Safely pass data to untrusted environments and back."
 name = "itsdangerous"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.0"
+version = "2.0.1"
 
 [[package]]
 category = "main"
@@ -713,10 +717,10 @@ description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
 python-versions = ">=3.6"
-version = "3.0.0"
+version = "3.0.1"
 
 [package.dependencies]
-MarkupSafe = ">=2.0.0rc2"
+MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
@@ -772,7 +776,7 @@ description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.0"
+version = "2.0.1"
 
 [[package]]
 category = "dev"
@@ -904,10 +908,13 @@ description = "Python docstring style checker"
 name = "pydocstyle"
 optional = false
 python-versions = ">=3.6"
-version = "6.0.0"
+version = "6.1.1"
 
 [package.dependencies]
 snowballstemmer = "*"
+
+[package.extras]
+toml = ["toml"]
 
 [[package]]
 category = "dev"
@@ -1275,7 +1282,7 @@ description = "The comprehensive WSGI web application library."
 name = "werkzeug"
 optional = false
 python-versions = ">=3.6"
-version = "2.0.0"
+version = "2.0.1"
 
 [package.dependencies]
 [package.dependencies.dataclasses]
@@ -1327,11 +1334,13 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [metadata]
 content-hash = "d2d4114fe75678318daadd371b19f39af63dbc343f6234f27faf9e2b54932d51"
+lock-version = "1.0"
 python-versions = ">=3.6,<4"
 
 [metadata.files]
 alembic = [
-    {file = "alembic-1.6.2.tar.gz", hash = "sha256:fb9a39a7c68e55490be962fb5f70463d384d340e6563d6e3911447778e3b4576"},
+    {file = "alembic-1.6.3-py2.py3-none-any.whl", hash = "sha256:5a01e9ac338e7380aea1d8a038fcc927cf309cc0b90ede4472c601282054f1b3"},
+    {file = "alembic-1.6.3.tar.gz", hash = "sha256:6d243986586709e9358accdd5ba35d16dd7ca5572681f0d683638ced407504c8"},
 ]
 aniso8601 = [
     {file = "aniso8601-7.0.0-py2.py3-none-any.whl", hash = "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"},
@@ -1367,12 +1376,12 @@ blinker = [
     {file = "blinker-1.4.tar.gz", hash = "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"},
 ]
 boto3 = [
-    {file = "boto3-1.17.73-py2.py3-none-any.whl", hash = "sha256:ce08b88a2d7a0ad8edb385f84ea4914296fee6813c66ebf0def956d5278de793"},
-    {file = "boto3-1.17.73.tar.gz", hash = "sha256:13cfe0e3ae1bdc7baf4272b1814a7e760fbb508b19d6ac3f472a6bbd64baad61"},
+    {file = "boto3-1.17.78-py2.py3-none-any.whl", hash = "sha256:1a87855123df1f18081a5fb8c1abde28d0096a03f6f3ebb06bcfb77cdffdae5e"},
+    {file = "boto3-1.17.78.tar.gz", hash = "sha256:2a5caee63d45fbdcc85e710c7f4146112f5d10b22fd0176643d2f2914cce54df"},
 ]
 botocore = [
-    {file = "botocore-1.20.73-py2.py3-none-any.whl", hash = "sha256:4b4aa58c61d4b125bc6ec1597924b2749e19de8f2c9a374ac087aa2561e71828"},
-    {file = "botocore-1.20.73.tar.gz", hash = "sha256:69dc0b6fdc0855f5a4f8b1d29c96b9cec44e71054fea0f968e5904d6ccfd4fd9"},
+    {file = "botocore-1.20.78-py2.py3-none-any.whl", hash = "sha256:37105b9434d73f9c4d4960ee54c8eb129120f4c6681eb16edf483f03c5e2326d"},
+    {file = "botocore-1.20.78.tar.gz", hash = "sha256:e74775f9e64e975787d76390fc5ac5aba875d726bb9ece3b7bd900205b430389"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -1422,8 +1431,8 @@ chardet = [
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
 ]
 click = [
-    {file = "click-8.0.0-py3-none-any.whl", hash = "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"},
-    {file = "click-8.0.0.tar.gz", hash = "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136"},
+    {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},
+    {file = "click-8.0.1.tar.gz", hash = "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -1525,8 +1534,8 @@ factory-boy = [
     {file = "factory_boy-3.2.0.tar.gz", hash = "sha256:401cc00ff339a022f84d64a4339503d1689e8263a4478d876e58a3295b155c5b"},
 ]
 faker = [
-    {file = "Faker-8.1.4-py3-none-any.whl", hash = "sha256:73562fb99b6046c5d26b8dd98a1437a896f8601c96382d835c656166159f4f59"},
-    {file = "Faker-8.1.4.tar.gz", hash = "sha256:c6a4a0a1dde71f16d489a3097661a87ae96329dbde4c3ece8a5ccc340441ade1"},
+    {file = "Faker-8.2.1-py3-none-any.whl", hash = "sha256:765cb52df0ca2dc5af0393048c1f60b2fec736095b379954c42c5c552f65838a"},
+    {file = "Faker-8.2.1.tar.gz", hash = "sha256:7397915ce793ac1e162eb89450a268c4404121389ca46264648a2a8c56d88624"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1555,8 +1564,8 @@ flake8-quotes = [
     {file = "flake8-quotes-3.2.0.tar.gz", hash = "sha256:3f1116e985ef437c130431ac92f9b3155f8f652fda7405ac22ffdfd7a9d1055e"},
 ]
 flask = [
-    {file = "Flask-2.0.0-py3-none-any.whl", hash = "sha256:1833a4b36ace08dfa1510d86f1bb6fc595d990ec1b838e03ac8dd80ac0705954"},
-    {file = "Flask-2.0.0.tar.gz", hash = "sha256:168e8507792cb8a3aa06afbe5d4d431d3e07c6318bc3893ceecb81aff09f848d"},
+    {file = "Flask-2.0.1-py3-none-any.whl", hash = "sha256:a6209ca15eb63fc9385f38e452704113d679511d9574d09b2cf9183ae7d20dc9"},
+    {file = "Flask-2.0.1.tar.gz", hash = "sha256:1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55"},
 ]
 flask-assets = [
     {file = "Flask-Assets-2.0.tar.gz", hash = "sha256:1dfdea35e40744d46aada72831f7613d67bf38e8b20ccaaa9e91fdc37aa3b8c2"},
@@ -1697,12 +1706,12 @@ isort = [
     {file = "isort-5.8.0.tar.gz", hash = "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6"},
 ]
 itsdangerous = [
-    {file = "itsdangerous-2.0.0-py3-none-any.whl", hash = "sha256:e2cb4ae918f07ab2a2f9a91dec2695bd1f25a19d31861a70015ad537ccb5e807"},
-    {file = "itsdangerous-2.0.0.tar.gz", hash = "sha256:99b1053ccce68066dfc0b4465ef8779027e6d577377c8270e21a3d6289cac111"},
+    {file = "itsdangerous-2.0.1-py3-none-any.whl", hash = "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c"},
+    {file = "itsdangerous-2.0.1.tar.gz", hash = "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.0-py3-none-any.whl", hash = "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6"},
-    {file = "Jinja2-3.0.0.tar.gz", hash = "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"},
+    {file = "Jinja2-3.0.1-py3-none-any.whl", hash = "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4"},
+    {file = "Jinja2-3.0.1.tar.gz", hash = "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"},
 ]
 jmespath = [
     {file = "jmespath-0.10.0-py2.py3-none-any.whl", hash = "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"},
@@ -1750,43 +1759,44 @@ lxml = [
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
 ]
 mako = [
+    {file = "Mako-1.1.4-py2.py3-none-any.whl", hash = "sha256:aea166356da44b9b830c8023cd9b557fa856bd8b4035d6de771ca027dfc5cc6e"},
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:45535241baa0fc0ba2a43961a1ac7562ca3257f46c4c3e9c0de38b722be41bd1"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:90053234a6479738fd40d155268af631c7fca33365f964f2208867da1349294b"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3b54a9c68995ef4164567e2cd1a5e16db5dac30b2a50c39c82db8d4afaf14f63"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f58b5ba13a5689ca8317b98439fccfbcc673acaaf8241c1869ceea40f5d585bf"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-win32.whl", hash = "sha256:a00dce2d96587651ef4fa192c17e039e8cfab63087c67e7d263a5533c7dad715"},
-    {file = "MarkupSafe-2.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:007dc055dbce5b1104876acee177dbfd18757e19d562cd440182e1f492e96b95"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a08cd07d3c3c17cd33d9e66ea9dee8f8fc1c48e2d11bd88fd2dc515a602c709b"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3c352ff634e289061711608f5e474ec38dbaa21e3e168820d53d5f4015e5b91b"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:32200f562daaab472921a11cbb63780f1654552ae49518196fc361ed8e12e901"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:fef86115fdad7ae774720d7103aa776144cf9b66673b4afa9bcaa7af990ed07b"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e79212d09fc0e224d20b43ad44bb0a0a3416d1e04cf6b45fed265114a5d43d20"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:79b2ae94fa991be023832e6bcc00f41dbc8e5fe9d997a02db965831402551730"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-win32.whl", hash = "sha256:3261fae28155e5c8634dd7710635fe540a05b58f160cef7713c7700cb9980e66"},
-    {file = "MarkupSafe-2.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e4570d16f88c7f3032ed909dc9e905a17da14a1c4cfd92608e3fda4cb1208bbd"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8f806bfd0f218477d7c46a11d3e52dc7f5fdfaa981b18202b7dc84bbc287463b"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e77e4b983e2441aff0c0d07ee711110c106b625f440292dfe02a2f60c8218bd6"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:031bf79a27d1c42f69c276d6221172417b47cb4b31cdc73d362a9bf5a1889b9f"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:83cf0228b2f694dcdba1374d5312f2277269d798e65f40344964f642935feac1"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4cc563836f13c57f1473bc02d1e01fc37bab70ad4ee6be297d58c1d66bc819bf"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d00a669e4a5bec3ee6dbeeeedd82a405ced19f8aeefb109a012ea88a45afff96"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-win32.whl", hash = "sha256:161d575fa49395860b75da5135162481768b11208490d5a2143ae6785123e77d"},
-    {file = "MarkupSafe-2.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:58bc9fce3e1557d463ef5cee05391a05745fd95ed660f23c1742c711712c0abb"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:3fb47f97f1d338b943126e90b79cad50d4fcfa0b80637b5a9f468941dbbd9ce5"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:dab0c685f21f4a6c95bfc2afd1e7eae0033b403dd3d8c1b6d13a652ada75b348"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:664832fb88b8162268928df233f4b12a144a0c78b01d38b81bdcf0fc96668ecb"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:df561f65049ed3556e5b52541669310e88713fdae2934845ec3606f283337958"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:24bbc3507fb6dfff663af7900a631f2aca90d5a445f272db5fc84999fa5718bc"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:87de598edfa2230ff274c4de7fcf24c73ffd96208c8e1912d5d0fee459767d75"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a19d39b02a24d3082856a5b06490b714a9d4179321225bbf22809ff1e1887cc8"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-win32.whl", hash = "sha256:4aca81a687975b35e3e80bcf9aa93fe10cd57fac37bf18b2314c186095f57e05"},
-    {file = "MarkupSafe-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:70820a1c96311e02449591cbdf5cd1c6a34d5194d5b55094ab725364375c9eb2"},
-    {file = "MarkupSafe-2.0.0.tar.gz", hash = "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
@@ -1848,8 +1858,11 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win32.whl", hash = "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
+    {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -1864,8 +1877,8 @@ pycparser = [
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pydocstyle = [
-    {file = "pydocstyle-6.0.0-py3-none-any.whl", hash = "sha256:d4449cf16d7e6709f63192146706933c7a334af7c0f083904799ccb851c50f6d"},
-    {file = "pydocstyle-6.0.0.tar.gz", hash = "sha256:164befb520d851dbcf0e029681b91f4f599c62c5cd8933fd54b1bfbd50e89e1f"},
+    {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
+    {file = "pydocstyle-6.1.1.tar.gz", hash = "sha256:1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc"},
 ]
 pyflakes = [
     {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
@@ -2019,8 +2032,8 @@ webtest = [
     {file = "WebTest-2.0.35.tar.gz", hash = "sha256:aac168b5b2b4f200af4e35867cf316712210e3d5db81c1cbdff38722647bb087"},
 ]
 werkzeug = [
-    {file = "Werkzeug-2.0.0-py3-none-any.whl", hash = "sha256:64c02f6495ba01eddd6625b3675f357cd358a73f1e38458a56ad86c5baa30b53"},
-    {file = "Werkzeug-2.0.0.tar.gz", hash = "sha256:3389bbfe6d40c6dd25e6d3f974155163c8b3de5bbda6a89342d4ab93fae80ba0"},
+    {file = "Werkzeug-2.0.1-py3-none-any.whl", hash = "sha256:6c1ec500dcdba0baa27600f6a22f6333d8b662d22027ff9f6202e3367413caa8"},
+    {file = "Werkzeug-2.0.1.tar.gz", hash = "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42"},
 ]
 whitenoise = [
     {file = "whitenoise-5.2.0-py2.py3-none-any.whl", hash = "sha256:05d00198c777028d72d8b0bbd234db605ef6d60e9410125124002518a48e515d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ description = "A database migration tool for SQLAlchemy."
 name = "alembic"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-version = "1.6.4"
+version = "1.6.5"
 
 [package.dependencies]
 Mako = "*"
@@ -103,10 +103,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.17.80"
+version = "1.17.85"
 
 [package.dependencies]
-botocore = ">=1.20.80,<1.21.0"
+botocore = ">=1.20.85,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.4.0,<0.5.0"
 
@@ -116,7 +116,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.20.80"
+version = "1.20.85"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
@@ -132,7 +132,7 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2020.12.5"
+version = "2021.5.30"
 
 [[package]]
 category = "main"
@@ -290,7 +290,7 @@ description = "Faker is a Python package that generates fake data for you."
 name = "faker"
 optional = false
 python-versions = ">=3.6"
-version = "8.2.1"
+version = "8.4.0"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
@@ -514,7 +514,7 @@ description = "SQLAlchemy database migrations for Flask applications using Alemb
 name = "flask-migrate"
 optional = false
 python-versions = "*"
-version = "3.0.0"
+version = "3.0.1"
 
 [package.dependencies]
 Flask = ">=0.9"
@@ -672,7 +672,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = ">=3.6"
-version = "4.0.1"
+version = "4.4.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -813,13 +813,13 @@ category = "main"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 name = "oauthlib"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.1.0"
+python-versions = ">=3.6"
+version = "3.1.1"
 
 [package.extras]
-rsa = ["cryptography"]
-signals = ["blinker"]
-signedtoken = ["cryptography", "pyjwt (>=1.0.0)"]
+rsa = ["cryptography (>=3.0.0,<4)"]
+signals = ["blinker (>=1.4.0)"]
+signedtoken = ["cryptography (>=3.0.0,<4)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
 category = "main"
@@ -1131,7 +1131,7 @@ description = "Database Abstraction Library"
 name = "sqlalchemy"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-version = "1.4.15"
+version = "1.4.17"
 
 [package.dependencies]
 [package.dependencies.greenlet]
@@ -1206,7 +1206,7 @@ description = "HTTP library with thread-safe connection pooling, file post, and 
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.26.4"
+version = "1.26.5"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -1341,8 +1341,8 @@ python-versions = ">=3.6,<4"
 
 [metadata.files]
 alembic = [
-    {file = "alembic-1.6.4-py2.py3-none-any.whl", hash = "sha256:dd0fd7109f82cd1d7ea64b26f287534a1ad1bc5deab79807926d5f3f5b3b517c"},
-    {file = "alembic-1.6.4.tar.gz", hash = "sha256:becb572c6701c90ca249f97fc1ae231468cc9516df367a350901eeb9310a8d43"},
+    {file = "alembic-1.6.5-py2.py3-none-any.whl", hash = "sha256:e78be5b919f5bb184e3e0e2dd1ca986f2362e29a2bc933c446fe89f39dbe4e9c"},
+    {file = "alembic-1.6.5.tar.gz", hash = "sha256:a21fedebb3fb8f6bbbba51a11114f08c78709377051384c9c5ead5705ee93a51"},
 ]
 aniso8601 = [
     {file = "aniso8601-7.0.0-py2.py3-none-any.whl", hash = "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"},
@@ -1378,16 +1378,16 @@ blinker = [
     {file = "blinker-1.4.tar.gz", hash = "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"},
 ]
 boto3 = [
-    {file = "boto3-1.17.80-py2.py3-none-any.whl", hash = "sha256:ef0747eaf1ec80489bcc698b03890a1a2e223d0ab6ebe2c086f654e5aafea045"},
-    {file = "boto3-1.17.80.tar.gz", hash = "sha256:5a30ba8be76bc73ca32b9ac2d344271a3f2c04a95fb52ffa95238b8caf82f06f"},
+    {file = "boto3-1.17.85-py2.py3-none-any.whl", hash = "sha256:ee82c1a97de02bd4e295b8cad440093d57869892ee5b8941a851758c45944cd5"},
+    {file = "boto3-1.17.85.tar.gz", hash = "sha256:8352dffe768af9e1471323c8e443cc66a114891572bf832bec3cc2eec47838f6"},
 ]
 botocore = [
-    {file = "botocore-1.20.80-py2.py3-none-any.whl", hash = "sha256:e47726efd7ebebc20f0747502747dab982489e6337ad24ca257b568e8216d300"},
-    {file = "botocore-1.20.80.tar.gz", hash = "sha256:a67923f9faa47833f13b4f3a3fc9a7f12499a58f51982faad4ddcc9132e59a1e"},
+    {file = "botocore-1.20.85-py2.py3-none-any.whl", hash = "sha256:7f54fa67b45cf767e1e4045741674cfdc47a3f424fe6f37570ae3ff1ca1e1e2a"},
+    {file = "botocore-1.20.85.tar.gz", hash = "sha256:d8992096d9c04e7be331924a59677e591cce6a3c6bd3a4c8fe26b00700d5255a"},
 ]
 certifi = [
-    {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
-    {file = "certifi-2020.12.5.tar.gz", hash = "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c"},
+    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
+    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
 ]
 cffi = [
     {file = "cffi-1.14.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991"},
@@ -1536,8 +1536,8 @@ factory-boy = [
     {file = "factory_boy-3.2.0.tar.gz", hash = "sha256:401cc00ff339a022f84d64a4339503d1689e8263a4478d876e58a3295b155c5b"},
 ]
 faker = [
-    {file = "Faker-8.2.1-py3-none-any.whl", hash = "sha256:765cb52df0ca2dc5af0393048c1f60b2fec736095b379954c42c5c552f65838a"},
-    {file = "Faker-8.2.1.tar.gz", hash = "sha256:7397915ce793ac1e162eb89450a268c4404121389ca46264648a2a8c56d88624"},
+    {file = "Faker-8.4.0-py3-none-any.whl", hash = "sha256:5b1c0781c0c2f6b177adf4018feec265bbcd0118b301dbec64a1908c29124ed6"},
+    {file = "Faker-8.4.0.tar.gz", hash = "sha256:c94240c40073400b269c50b14da765fd4d3b4dda8ae25c2753afc809c72f1062"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -1602,8 +1602,8 @@ flask-login = [
     {file = "Flask_Login-0.5.0-py2.py3-none-any.whl", hash = "sha256:7451b5001e17837ba58945aead261ba425fdf7b4f0448777e597ddab39f4fba0"},
 ]
 flask-migrate = [
-    {file = "Flask-Migrate-3.0.0.tar.gz", hash = "sha256:a6607e66bf1d68489b2281ead5caa6fdf7a21b71984fae922ef5f915ac45bbcb"},
-    {file = "Flask_Migrate-3.0.0-py2.py3-none-any.whl", hash = "sha256:fadbc9cbf782e95cf7cea63ceff11972d55f534bef86dae4d9d0ab9372bd62dd"},
+    {file = "Flask-Migrate-3.0.1.tar.gz", hash = "sha256:4d42e8f861d78cb6e9319afcba5bf76062e5efd7784184dd2a1cccd9de34a702"},
+    {file = "Flask_Migrate-3.0.1-py2.py3-none-any.whl", hash = "sha256:df9043d2050df3c0e0f6313f6b529b62c837b6033c20335e9d0b4acdf2c40e23"},
 ]
 flask-misaka = [
     {file = "Flask-Misaka-1.0.0.tar.gz", hash = "sha256:f423c3beb5502742a57330a272f81d53223f6f99d45cc45b03926e3a3034f589"},
@@ -1696,8 +1696,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.0.1-py3-none-any.whl", hash = "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"},
-    {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
+    {file = "importlib_metadata-4.4.0-py3-none-any.whl", hash = "sha256:960d52ba7c21377c990412aca380bf3642d734c2eaab78a2c39319f67c6a5786"},
+    {file = "importlib_metadata-4.4.0.tar.gz", hash = "sha256:e592faad8de1bda9fe920cf41e15261e7131bcf266c30306eec00e8e225c1dd5"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1810,8 +1810,8 @@ misaka = [
     {file = "misaka-2.1.1.tar.gz", hash = "sha256:62f35254550095d899fc2ab8b33e156fc5e674176f074959cbca43cf7912ecd7"},
 ]
 oauthlib = [
-    {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
-    {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
+    {file = "oauthlib-3.1.1-py2.py3-none-any.whl", hash = "sha256:42bf6354c2ed8c6acb54d971fce6f88193d97297e18602a3a886603f9d7730cc"},
+    {file = "oauthlib-3.1.1.tar.gz", hash = "sha256:8f0215fcc533dd8dd1bee6f4c412d4f0cd7297307d43ac61666389e3bc3198a3"},
 ]
 packaging = [
     {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
@@ -1954,36 +1954,36 @@ soupsieve = [
     {file = "soupsieve-2.2.1.tar.gz", hash = "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.4.15-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:22141a05d0f60df57ae334b589dbd081213c257a80d448ff499a3b6efd1998d3"},
-    {file = "SQLAlchemy-1.4.15-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c12b7dc8e37442eef74afc7f4f99eb4ec6d796215fc4499ca32c7ca48f353cb3"},
-    {file = "SQLAlchemy-1.4.15-cp27-cp27m-win32.whl", hash = "sha256:5ec8d34c8a9f467178b581a48ccef9163cb553015925e4665d7af495c3c958d9"},
-    {file = "SQLAlchemy-1.4.15-cp27-cp27m-win_amd64.whl", hash = "sha256:324fb6e1f41afd5bdf0a34cfd011999213dcd543b83efa9dcc868f9e64a9ff7f"},
-    {file = "SQLAlchemy-1.4.15-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8a4d26fa3f00344f9b34402f8a52b58941ba0d4b0ca80d5b05be39ec35b2eb8e"},
-    {file = "SQLAlchemy-1.4.15-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:a2c2965698807e53f1f4da1cc9d68f1c1dda9139ef5a96d18921be4e253d687e"},
-    {file = "SQLAlchemy-1.4.15-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:10068984bf334dd0b03ea83550b45667be968789bd0033215d30053649b0dd1b"},
-    {file = "SQLAlchemy-1.4.15-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:beb1a6560d65c46d52c6ac402a806b8d24a6f2ee3f96fbbd4cfa371db24c3b3a"},
-    {file = "SQLAlchemy-1.4.15-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6521e3b2f58a9ec2ad84b24efa88e61b8d355a6e481b459dcb64cadd14ba74d7"},
-    {file = "SQLAlchemy-1.4.15-cp36-cp36m-win32.whl", hash = "sha256:6072231bdf976722ce92a8d1335e5b2d7ed0d7ee28667c00537b58cf7d68c41d"},
-    {file = "SQLAlchemy-1.4.15-cp36-cp36m-win_amd64.whl", hash = "sha256:4d3cc347db370cc0d14dd724a9f280f4b4a0447ad77a228dd20792c4736f0b0e"},
-    {file = "SQLAlchemy-1.4.15-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:3845b3af8a412230cc91fd32103a74d558566fea96c1b8775abb7ec65c3ef5de"},
-    {file = "SQLAlchemy-1.4.15-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8410319b084b708c4ee0bc0d82f4b01623883595b5d8333ec704788940cc7293"},
-    {file = "SQLAlchemy-1.4.15-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c1151b26f8bc53a69dc82f782560568186625d7b70bece4914ca459be1f539e1"},
-    {file = "SQLAlchemy-1.4.15-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec88907048fbade9712de08e648203d95221cad5a3b8a459cc3724c1bffb9281"},
-    {file = "SQLAlchemy-1.4.15-cp37-cp37m-win32.whl", hash = "sha256:e3e627e0f57b6f101ecabe39b90261625deedc91ec659cd4226f522bd3dd0020"},
-    {file = "SQLAlchemy-1.4.15-cp37-cp37m-win_amd64.whl", hash = "sha256:70036b7fc86b8dc0c04e186107ee6371e8f9a8fb35980d483cc4d114b298b19f"},
-    {file = "SQLAlchemy-1.4.15-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:21e0d18dab96515670e96e53a7e7207ba5cee6cd56b312447f2772d61d37d9b8"},
-    {file = "SQLAlchemy-1.4.15-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:260a79673c1234a20d7a16ee3ac6711c3f1b81363ebb208921d512fdb9f6a12e"},
-    {file = "SQLAlchemy-1.4.15-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7c2ff45be0eacf4ac290fe546064df257e8be899e3b191a39df3e41a2d9a0797"},
-    {file = "SQLAlchemy-1.4.15-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:403e94a1862c6217e7bd71950191d58ad313ea976e7d128c9afb6b9934d2d6a2"},
-    {file = "SQLAlchemy-1.4.15-cp38-cp38-win32.whl", hash = "sha256:05ea2c275603b3fb5ce761d0ccabe47a376ed8a48f70e1d4c80a71f185224d3f"},
-    {file = "SQLAlchemy-1.4.15-cp38-cp38-win_amd64.whl", hash = "sha256:75becbc5ac452dac28d8d5aeb0406ddd3a1d808726a5fd0d5b696fad0b71d951"},
-    {file = "SQLAlchemy-1.4.15-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:92dfb2ac7b44873901f87f3e0bb5c63469b76c5c3cabbf8124332e0dd1172410"},
-    {file = "SQLAlchemy-1.4.15-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a31062468a184eb046eb09eadf296e3652d916793e32829082b3eda3367be5e8"},
-    {file = "SQLAlchemy-1.4.15-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6248934b6e1841a794d5d12e2d43e32c2a7c64a36a059c612d4d66b312b3604f"},
-    {file = "SQLAlchemy-1.4.15-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3fab43abe335a44aed3fbf98be619f021cbee2160718ecedc5fe4fa41296f7e"},
-    {file = "SQLAlchemy-1.4.15-cp39-cp39-win32.whl", hash = "sha256:5642d64feeab65ae662c8e46eccc3db4a3100c9572dcfa29063751e2d1940e78"},
-    {file = "SQLAlchemy-1.4.15-cp39-cp39-win_amd64.whl", hash = "sha256:17ce3009c69ac361d871bed3c9c30cf405d2739934d83322272bd455a697c874"},
-    {file = "SQLAlchemy-1.4.15.tar.gz", hash = "sha256:0ff100c75cd175f35f4d24375a0b3d82461f5b1af5fc8d112ef0e5ceea8049e6"},
+    {file = "SQLAlchemy-1.4.17-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c367ed95d41df584f412a9419b5ece85b0d6c2a08a51ae13ae47ef74ff9a9349"},
+    {file = "SQLAlchemy-1.4.17-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fdad4a33140b77df61d456922b7974c1f1bb2c35238f6809f078003a620c4734"},
+    {file = "SQLAlchemy-1.4.17-cp27-cp27m-win32.whl", hash = "sha256:f1c68f7bd4a57ffdb85eab489362828dddf6cd565a4c18eda4c446c1d5d3059d"},
+    {file = "SQLAlchemy-1.4.17-cp27-cp27m-win_amd64.whl", hash = "sha256:ee6e7ca09ff274c55d19a1e15ee6f884fa0230c0d9b8d22a456e249d08dee5bf"},
+    {file = "SQLAlchemy-1.4.17-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5f00a2be7d777119e15ccfb5ba0b2a92e8a193959281089d79821a001095f80"},
+    {file = "SQLAlchemy-1.4.17-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:1dd77acbc19bee9c0ba858ff5e4e5d5c60895495c83b4df9bcdf4ad5e9b74f21"},
+    {file = "SQLAlchemy-1.4.17-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5732858e56d32fa7e02468f4fd2d8f01ddf709e5b93d035c637762890f8ed8b6"},
+    {file = "SQLAlchemy-1.4.17-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:949ac299903d2ed8419086f81847381184e2264f3431a33af4679546dcc87f01"},
+    {file = "SQLAlchemy-1.4.17-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:196fb6bb2733834e506c925d7532f8eabad9d2304deef738a40846e54c31e236"},
+    {file = "SQLAlchemy-1.4.17-cp36-cp36m-win32.whl", hash = "sha256:bde055c019e6e449ebc4ec61abd3e08690abeb028c7ada2a3b95d8e352b7b514"},
+    {file = "SQLAlchemy-1.4.17-cp36-cp36m-win_amd64.whl", hash = "sha256:b0ad951a6e590bbcfbfeadc5748ef5ec8ede505a8119a71b235f7481cc08371c"},
+    {file = "SQLAlchemy-1.4.17-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:82922a320d38d7d6aa3a8130523ec7e8c70fa95f7ca7d0fd6ec114b626e4b10b"},
+    {file = "SQLAlchemy-1.4.17-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e133e2551fa99c75849848a4ac08efb79930561eb629dd7d2dc9b7ee05256e6"},
+    {file = "SQLAlchemy-1.4.17-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7e45043fe11d503e1c3f9dcf5b42f92d122a814237cd9af68a11dae46ecfcae1"},
+    {file = "SQLAlchemy-1.4.17-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:461a4ea803ce0834822f372617a68ac97f9fa1281f2a984624554c651d7c3ae1"},
+    {file = "SQLAlchemy-1.4.17-cp37-cp37m-win32.whl", hash = "sha256:4d93b62e98248e3e1ac1e91c2e6ee1e7316f704be1f734338b350b6951e6c175"},
+    {file = "SQLAlchemy-1.4.17-cp37-cp37m-win_amd64.whl", hash = "sha256:a2d225c8863a76d15468896dc5af36f1e196b403eb9c7e0151e77ffab9e7df57"},
+    {file = "SQLAlchemy-1.4.17-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:b59b2c0a3b1d93027f6b6b8379a50c354483fe1ebe796c6740e157bb2e06d39a"},
+    {file = "SQLAlchemy-1.4.17-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7222f3236c280fab3a2d76f903b493171f0ffc29667538cc388a5d5dd0216a88"},
+    {file = "SQLAlchemy-1.4.17-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4b09191ed22af149c07a880f309b7740f3f782ff13325bae5c6168a6aa57e715"},
+    {file = "SQLAlchemy-1.4.17-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:216ff28fe803885ceb5b131dcee6507d28d255808dd5bcffcb3b5fa75be2e102"},
+    {file = "SQLAlchemy-1.4.17-cp38-cp38-win32.whl", hash = "sha256:dde05ae0987e43ec84e64d6722ce66305eda2a5e2b7d6fda004b37aabdfbb909"},
+    {file = "SQLAlchemy-1.4.17-cp38-cp38-win_amd64.whl", hash = "sha256:bc89e37c359dcd4d75b744e5e81af128ba678aa2ecea4be957e80e6e958a1612"},
+    {file = "SQLAlchemy-1.4.17-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:4c5e20666b33b03bf7f14953f0deb93007bf8c1342e985bd7c7cf25f46fac579"},
+    {file = "SQLAlchemy-1.4.17-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f63e1f531a8bf52184e2afb53648511f3f8534decb7575b483a583d3cd8d13ed"},
+    {file = "SQLAlchemy-1.4.17-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7dc3d3285fb682316d580d84e6e0840fdd8ffdc05cb696db74b9dd746c729908"},
+    {file = "SQLAlchemy-1.4.17-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58c02d1771bb0e61bc9ced8f3b36b5714d9ece8fd4bdbe2a44a892574c3bbc3c"},
+    {file = "SQLAlchemy-1.4.17-cp39-cp39-win32.whl", hash = "sha256:6fe1c8dc26bc0005439cb78ebc78772a22cccc773f5a0e67cb3002d791f53f0f"},
+    {file = "SQLAlchemy-1.4.17-cp39-cp39-win_amd64.whl", hash = "sha256:7eb55d5583076c03aaf1510473fad2a61288490809049cb31028af56af7068ee"},
+    {file = "SQLAlchemy-1.4.17.tar.gz", hash = "sha256:651cdb3adcee13624ba22d5ff3e96f91e16a115d2ca489ddc16a8e4c217e8509"},
 ]
 testfixtures = [
     {file = "testfixtures-6.17.1-py2.py3-none-any.whl", hash = "sha256:9ed31e83f59619e2fa17df053b241e16e0608f4580f7b5a9333a0c9bdcc99137"},
@@ -2003,8 +2003,8 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.0.tar.gz", hash = "sha256:50b6f157849174217d0656f99dc82fe932884fb250826c18350e159ec6cdf342"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.4-py2.py3-none-any.whl", hash = "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df"},
-    {file = "urllib3-1.26.4.tar.gz", hash = "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"},
+    {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},
+    {file = "urllib3-1.26.5.tar.gz", hash = "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"},
 ]
 urlobject = [
     {file = "URLObject-2.4.3.tar.gz", hash = "sha256:47b2e20e6ab9c8366b2f4a3566b6ff4053025dad311c4bb71279bbcfa2430caa"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ description = "A database migration tool for SQLAlchemy."
 name = "alembic"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
-version = "1.6.3"
+version = "1.6.4"
 
 [package.dependencies]
 Mako = "*"
@@ -103,10 +103,10 @@ description = "The AWS SDK for Python"
 name = "boto3"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.17.78"
+version = "1.17.80"
 
 [package.dependencies]
-botocore = ">=1.20.78,<1.21.0"
+botocore = ">=1.20.80,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.4.0,<0.5.0"
 
@@ -116,7 +116,7 @@ description = "Low-level, data-driven core of boto 3."
 name = "botocore"
 optional = false
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-version = "1.20.78"
+version = "1.20.80"
 
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
@@ -561,13 +561,16 @@ category = "main"
 description = "Simple integration of Flask and WTForms."
 name = "flask-wtf"
 optional = false
-python-versions = "*"
-version = "0.14.3"
+python-versions = ">= 3.6"
+version = "0.15.1"
 
 [package.dependencies]
 Flask = "*"
 WTForms = "*"
 itsdangerous = "*"
+
+[package.extras]
+email = ["email-validator"]
 
 [[package]]
 category = "main"
@@ -1334,13 +1337,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 
 [metadata]
 content-hash = "d2d4114fe75678318daadd371b19f39af63dbc343f6234f27faf9e2b54932d51"
-lock-version = "1.0"
 python-versions = ">=3.6,<4"
 
 [metadata.files]
 alembic = [
-    {file = "alembic-1.6.3-py2.py3-none-any.whl", hash = "sha256:5a01e9ac338e7380aea1d8a038fcc927cf309cc0b90ede4472c601282054f1b3"},
-    {file = "alembic-1.6.3.tar.gz", hash = "sha256:6d243986586709e9358accdd5ba35d16dd7ca5572681f0d683638ced407504c8"},
+    {file = "alembic-1.6.4-py2.py3-none-any.whl", hash = "sha256:dd0fd7109f82cd1d7ea64b26f287534a1ad1bc5deab79807926d5f3f5b3b517c"},
+    {file = "alembic-1.6.4.tar.gz", hash = "sha256:becb572c6701c90ca249f97fc1ae231468cc9516df367a350901eeb9310a8d43"},
 ]
 aniso8601 = [
     {file = "aniso8601-7.0.0-py2.py3-none-any.whl", hash = "sha256:d10a4bf949f619f719b227ef5386e31f49a2b6d453004b21f02661ccc8670c7b"},
@@ -1376,12 +1378,12 @@ blinker = [
     {file = "blinker-1.4.tar.gz", hash = "sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6"},
 ]
 boto3 = [
-    {file = "boto3-1.17.78-py2.py3-none-any.whl", hash = "sha256:1a87855123df1f18081a5fb8c1abde28d0096a03f6f3ebb06bcfb77cdffdae5e"},
-    {file = "boto3-1.17.78.tar.gz", hash = "sha256:2a5caee63d45fbdcc85e710c7f4146112f5d10b22fd0176643d2f2914cce54df"},
+    {file = "boto3-1.17.80-py2.py3-none-any.whl", hash = "sha256:ef0747eaf1ec80489bcc698b03890a1a2e223d0ab6ebe2c086f654e5aafea045"},
+    {file = "boto3-1.17.80.tar.gz", hash = "sha256:5a30ba8be76bc73ca32b9ac2d344271a3f2c04a95fb52ffa95238b8caf82f06f"},
 ]
 botocore = [
-    {file = "botocore-1.20.78-py2.py3-none-any.whl", hash = "sha256:37105b9434d73f9c4d4960ee54c8eb129120f4c6681eb16edf483f03c5e2326d"},
-    {file = "botocore-1.20.78.tar.gz", hash = "sha256:e74775f9e64e975787d76390fc5ac5aba875d726bb9ece3b7bd900205b430389"},
+    {file = "botocore-1.20.80-py2.py3-none-any.whl", hash = "sha256:e47726efd7ebebc20f0747502747dab982489e6337ad24ca257b568e8216d300"},
+    {file = "botocore-1.20.80.tar.gz", hash = "sha256:a67923f9faa47833f13b4f3a3fc9a7f12499a58f51982faad4ddcc9132e59a1e"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -1617,8 +1619,8 @@ flask-talisman = [
     {file = "flask_talisman-0.7.0-py2.py3-none-any.whl", hash = "sha256:eaa754f4b771dfbe473843391d69643b79e3a38c865790011ac5e4179c68e3ec"},
 ]
 flask-wtf = [
-    {file = "Flask-WTF-0.14.3.tar.gz", hash = "sha256:d417e3a0008b5ba583da1763e4db0f55a1269d9dd91dcc3eb3c026d3c5dbd720"},
-    {file = "Flask_WTF-0.14.3-py2.py3-none-any.whl", hash = "sha256:57b3faf6fe5d6168bda0c36b0df1d05770f8e205e18332d0376ddb954d17aef2"},
+    {file = "Flask-WTF-0.15.1.tar.gz", hash = "sha256:ff177185f891302dc253437fe63081e7a46a4e99aca61dfe086fb23e54fff2dc"},
+    {file = "Flask_WTF-0.15.1-py2.py3-none-any.whl", hash = "sha256:6ff7af73458f182180906a37a783e290bdc8a3817fe4ad17227563137ca285bf"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -1759,7 +1761,6 @@ lxml = [
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
 ]
 mako = [
-    {file = "Mako-1.1.4-py2.py3-none-any.whl", hash = "sha256:aea166356da44b9b830c8023cd9b557fa856bd8b4035d6de771ca027dfc5cc6e"},
     {file = "Mako-1.1.4.tar.gz", hash = "sha256:17831f0b7087c313c0ffae2bcbbd3c1d5ba9eeac9c38f2eb7b50e8c99fe9d5ab"},
 ]
 markupsafe = [
@@ -1858,11 +1859,8 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win32.whl", hash = "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77"},
-    {file = "psycopg2_binary-2.8.6-cp39-cp39-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
-    {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
-    {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,7 +5,7 @@ bcrypt==3.2.0
 beautifulsoup4==4.9.3
 bleach==3.3.0
 boto3>=1.17,<2
-certifi==2020.12.5
+certifi==2021.5.30
 cffi==1.14.5
 chardet==4.0.0
 Click>=8.0.0,<9
@@ -20,7 +20,7 @@ Flask-Cors==3.0.10
 Flask-Dance==5.0.0
 Flask-Hashing==1.1
 Flask-Login==0.5.0
-Flask-Migrate==3.0.0
+Flask-Migrate==3.0.1
 Flask-Misaka==1.0.0
 Flask-SQLAlchemy==2.5.1
 flask-talisman==0.7.0
@@ -53,7 +53,7 @@ requests==2.25.1
 requests-oauthlib==1.3.0
 rx==1.6.1
 six>=1.16.0,<2
-sqlalchemy==1.4.13
+sqlalchemy==1.4.17
 urlobject==2.4.3
 webassets==2.0
 webencodings==0.5.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 -i https://pypi.org/simple
-alembic==1.6.3
+alembic>=1.6,<2
 aniso8601==7.0.0
 bcrypt==3.2.0
 beautifulsoup4==4.9.3
@@ -24,7 +24,7 @@ Flask-Migrate==3.0.0
 Flask-Misaka==1.0.0
 Flask-SQLAlchemy==2.5.1
 flask-talisman==0.7.0
-Flask-WTF==0.14.3
+Flask-WTF==0.15.1
 future==0.18.2
 graphene==2.1.8
 graphql-core==2.3.2

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 -i https://pypi.org/simple
-alembic==1.6.0
+alembic==1.6.3
 aniso8601==7.0.0
 bcrypt==3.2.0
 beautifulsoup4==4.9.3
@@ -32,12 +32,12 @@ graphql-relay==2.0.1
 gunicorn==20.1.0
 email_validator==1.1.2
 idna==2.10
-itsdangerous==2.0.0
+itsdangerous==2.0.1
 jinja2==2.11.3
 jsmin==2.2.2
 lxml==4.6.3
 mako==1.1.4
-markupsafe==2.0.0
+markupsafe==2.0.1
 micawber==0.5.3
 promise==2.3
 psycopg2-binary==2.8.6

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -43,17 +43,19 @@ class TestProgressTree:
         rC.save()
         rD = Resource(name="Code D", type_id=200, progress_tip=10)
         rD.save()
+        rE = Resource(name="Code E", type_id=200, progress_tip=5)
+        rE.save()
         rN = Resource(name="Code N", type_id=100, is_visible=False)
         rN.save()
 
         allres = SuggestionsByProgress()
-        assert len(allres) == 4
+        assert len(allres) == 5 # one is hidden
         assert allres[-1] == rB
 
         rTree = SuggestionsTreeForEvent()
         assert rTree[-1]['index'] == -1 # etc
         assert len(rTree) == 7 + 1 # defaults plus etc
-        assert rTree[0]['resources'] == [] # idea or challenge
-        assert rTree[1]['resources'] == [rB]
-        assert rTree[2]['resources'] == [rC, rD]
+        assert rTree[0]['resources'] == [rB] # idea or challenge
+        assert rTree[1]['resources'] == [rE] # team has formed
+        assert rTree[2]['resources'] == [rC, rD] # researching
         assert rTree[-1]['resources'] == [rA]

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -4,12 +4,15 @@
 See: http://webtest.readthedocs.org/
 """
 from flask import url_for
+import pytest
 
-from dribdat.user.models import Project
+from dribdat.user.models import Project, Resource
+from dribdat.user import projectProgressList
 
 from .factories import ProjectFactory
 
 from dribdat.onebox import make_onebox
+from dribdat.aggregation import *
 
 class TestProjects:
     """Project features."""
@@ -25,3 +28,32 @@ EOF""" % (url, url)
 
         result = make_onebox(test_markdown)
         assert 'onebox' in result
+
+
+@pytest.mark.usefixtures('db')
+class TestProgressTree:
+    """Project suggestions tests."""
+
+    def test_resource_tree(self, db):
+        rA = Resource(name="Code A", type_id=100, progress_tip=None)
+        rA.save()
+        rB = Resource(name="Code B", type_id=300, progress_tip=0)
+        rB.save()
+        rC = Resource(name="Code C", type_id=200, progress_tip=10)
+        rC.save()
+        rD = Resource(name="Code D", type_id=200, progress_tip=10)
+        rD.save()
+        rN = Resource(name="Code N", type_id=100, is_visible=False)
+        rN.save()
+
+        allres = SuggestionsByProgress()
+        assert len(allres) == 4
+        assert allres[-1] == rB
+
+        rTree = SuggestionsTreeForEvent()
+        assert rTree[-1]['index'] == -1 # etc
+        assert len(rTree) == 7 + 1 # defaults plus etc
+        assert rTree[0]['resources'] == [] # idea or challenge
+        assert rTree[1]['resources'] == [rB]
+        assert rTree[2]['resources'] == [rC, rD]
+        assert rTree[-1]['resources'] == [rA]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,8 @@ import datetime as dt
 import pytest
 import pytz
 
-from dribdat.user.models import Role, User, Event
+from dribdat.user.models import Role, User, Event, Resource
+from dribdat.user.constants import getResourceType
 from dribdat.utils import timesince
 from dribdat.settings import Config
 
@@ -113,3 +114,23 @@ class TestEvent:
         assert event.countdown is not None
         assert event.countdown == tz_event
         assert timesince(event.countdown, until=True) == "%d hours to go" % timediff_hours
+
+
+@pytest.mark.usefixtures('db')
+class TestResource:
+    """Resource ('Component') tests."""
+
+    def test_resource_collection(self, db):
+        resourceA = Resource(name="Test A", type_id=100)
+        resourceA.save()
+        resourceB = Resource(name="Test B", type_id=200)
+        resourceB.save()
+        resourceC = Resource(name="Test C", type_id=0)
+        resourceC.save()
+        resourceN = Resource(name="Test N", type_id=None)
+        resourceN.save()
+
+        assert resourceA.name == "Test A"
+        assert getResourceType(resourceB) == 'Code'
+        assert getResourceType(resourceC) == 'Other'
+        assert getResourceType(resourceN) == 'Other'


### PR DESCRIPTION
In this PR the long desired of commit history support has been added, initially using the GitHub [REST API](https://docs.github.com/en/rest). Integration with [GitLab](https://docs.gitlab.com/ee/api/commits.html), [Bitbucket](https://developer.atlassian.com/server/bitbucket/how-tos/command-line-rest/) or other providers will be [straightforward](https://github.com/hackathons-ftw/dribdat/pull/246/files#diff-a7d5353d2d4004d81aae6e3394a0fa91f0c27e21a9f530cde27c6b41d8baa245), assuming the API provides open access to public commits.

![Screenshot from 2021-05-25 23-32-52](https://user-images.githubusercontent.com/31819/119573873-23a9e880-bdb5-11eb-8d6e-5fba631a13f7.png)
_Example commit from project [Vega](https://github.com/vega/vega/commit/61b0ccc88952fe065dbd4d1df45ab3d717fdf46d)_

- When Syncing a project, entries from the git log are added to the project Log, as long as they are within the event time span. Note that only the last 50 commits are taken into account.
- Event **Instructions** are now hidden when users are not logged in. There is a log-in reminder instead.
- The Resources page also shows the event instructions below, when logged in.
- The home page shows a shortened/simplified form of past/upcoming event descriptions.
- An API option (`?moar=1`) allows the full project data to be downloaded.