### PR TITLE
From plain progress to data pipelines

### DIFF
--- a/dribdat/aggregation.py
+++ b/dribdat/aggregation.py
@@ -141,7 +141,7 @@ def GetEventUsers(event):
     users = []
     userlist = []
     for p in event.projects:
-        for u in p.team():
+        for u in p.get_team():
             if u.active and u.id not in userlist:
                 userlist.append(u.id)
                 users.append(u)

--- a/dribdat/apiutils.py
+++ b/dribdat/apiutils.py
@@ -93,11 +93,12 @@ def expand_project_urls(projects, host_url):
         p['team'] = ', '.join(p['team'])
     return projects
 
+
 def get_schema_for_user_projects(user, host_url):
     """ Generates the metadata for a given user's projects """
     my_projects = user.joined_projects()
     if len(my_projects) == 0:
-        return { 'message': "You must join and contribute to at least one project." }
+        return {'message': "Please join and contribute to at least 1 project."}
     my_events = {}
     for p in my_projects:
         if p.event_id not in my_events.keys():
@@ -108,9 +109,10 @@ def get_schema_for_user_projects(user, host_url):
             p.get_schema(host_url)
         )
     # Sort in reverse chronological order
-    my_schema = [ my_events[e] for e in my_events ]
+    my_schema = [my_events[e] for e in my_events]
     my_schema.sort(key=lambda x: x['startDate'], reverse=True)
     return my_schema
+
 
 def gen_rows(csvdata):
     """ Generate rows from data """

--- a/dribdat/public/api.py
+++ b/dribdat/public/api.py
@@ -184,7 +184,7 @@ def project_info_json(project_id):
     """ API: Outputs JSON info for a specific project """
     project = Project.query.filter_by(id=project_id).first_or_404()
     activities = []
-    for user in project.team():
+    for user in project.get_team():
         activities.append({
             'id': user.id,
             'name': user.username,

--- a/dribdat/public/project.py
+++ b/dribdat/public/project.py
@@ -148,13 +148,14 @@ def project_post(project_id):
                 for a in projectProgressList(True, False):
                     if found_next:
                         project.progress = a[0]
-                        flash("Promoted to stage '%s'" % project.progress, 'info')
+                        flash("Promoted to stage '%s'" %
+                              project.progress, 'info')
                         break
                     if a[0] == project.progress or \
                         not project.progress or \
                             project.progress < 0:
                         found_next = True
-            #if not all_valid or not found_next:
+            # if not all_valid or not found_next:
             #    flash('Your project did not meet stage requirements.', 'info')
 
         # Update project data
@@ -281,7 +282,10 @@ def project_action(project_id, of_type=None, as_view=True, then_redirect=False,
 @login_required
 def project_star(project_id):
     if not isUserActive(current_user):
-        flash("User currently not allowed to join projects. Please ask the organizers for activation.", 'warning')
+        flash(
+            "User currently not allowed to join projects - please contact "
+            + " organizers for activation.", 'warning'
+        )
         return redirect(url_for('project.project_view', project_id=project_id))
     flash('Welcome to the team!', 'success')
     return project_action(project_id, 'star', then_redirect=True)
@@ -400,4 +404,5 @@ def project_autoupdate(project_id):
             flash("Thanks for contributing on %s" % data['type'], 'success')
         else:
             flash("Could not sync: remote README has no data.", 'warning')
-    return redirect(url_for('project.project_view_posted', project_id=project_id))
+    return redirect(url_for(
+        'project.project_view_posted', project_id=project_id))

--- a/dribdat/public/project.py
+++ b/dribdat/public/project.py
@@ -247,7 +247,7 @@ def project_action(project_id, of_type=None, as_view=True, then_redirect=False,
     allow_post = starred  # and not event.lock_resources
     allow_edit = allow_edit and not event.lock_editing
     # Obtain list of team members (performance!)
-    project_team = project.team()
+    project_team = project.team
     if allow_post:
         # Evaluate project progress
         stage, all_valid = validateProjectData(project)

--- a/dribdat/public/project.py
+++ b/dribdat/public/project.py
@@ -247,7 +247,7 @@ def project_action(project_id, of_type=None, as_view=True, then_redirect=False,
     allow_post = starred  # and not event.lock_resources
     allow_edit = allow_edit and not event.lock_editing
     # Obtain list of team members (performance!)
-    project_team = project.team
+    project_team = project.get_team()
     if allow_post:
         # Evaluate project progress
         stage, all_valid = validateProjectData(project)

--- a/dribdat/public/views.py
+++ b/dribdat/public/views.py
@@ -74,11 +74,6 @@ def home():
     today = datetime.utcnow()
     events_next = timed_events.filter(Event.ends_at > today).all()
     events_past = timed_events.filter(Event.ends_at < today).all()
-    # Select a featured event if none is selected
-    if cur_event is None:
-        events_now = timed_events.filter(
-            Event.starts_at <= today).filter(Event.ends_at >= today)
-        cur_event = events_now.first()
     # Select Resource-type events
     resource_events = events.filter(
         Event.lock_resources).order_by(Event.name.asc()).all()

--- a/dribdat/public/views.py
+++ b/dribdat/public/views.py
@@ -209,7 +209,6 @@ def event_print(event_id):
 
 
 @blueprint.route('/event/start', methods=['GET'])
-@login_required
 def event_start():
     if not current_app.config['DRIBDAT_ALLOW_EVENTS']:
         if not current_user.is_admin:

--- a/dribdat/static/css/honeycomb.css
+++ b/dribdat/static/css/honeycomb.css
@@ -1,20 +1,21 @@
 /*
- * http://codepen.io/gpyne/pen/iElhp/ ⌘ from a pen by Graham Pyne
- */
+* http://codepen.io/gpyne/pen/iElhp/ ⌘ from a pen by Graham Pyne
+*/
+
 .hexagon {
   position: relative;
   display: inline-block;
   /* left/right margin approx. 25% of .hexagon width + spacing */
-  margin: 1px 21px;
+  margin: 1px 18px;
   background-color: hsl(220, 75%, 75%);
   text-align: center;
 }
 .hexagon, .hexagon::before, .hexagon::after {
   /* easy way: height is width * 1.732
   actual formula is 2*(width/(2*Math.tan(Math.PI/6)))
-  remove border-radius for straight edges on hexagons */
-  width: 82px;
-  height: 142px;
+  remove border-radius for sharp corners on hexagons */
+  width: 67px;
+  height: 116px;
   border-radius: 20%/5%;
 }
 .hexagon::before {
@@ -33,7 +34,7 @@
 }
 .hexagon:nth-child(even) {
   /* top approx. 50% of .hexagon height + spacing */
-  top: 73px;
+  top: 59px;
 }
 .hexagon:hover {
   background-color: hsla(60, 75%, 75%, 1.0);
@@ -44,13 +45,23 @@
   background-color: hsla(60, 75%, 50%, 1.0);
   z-index: 110;
 }
+.hexanone {
+  position: relative;
+  display: inline-block;
+  width: 67px;
+  height: 116px;
+  margin: 1px 18px;
+}
+.hexanone:nth-child(even) {
+  top: 59px;
+}
 .hexagontent {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   width: 140%;
-  font-size: 1.0rem;
+  font-size: 1.4rem;
   line-height: 1.2;
   z-index: 100;
 }

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -406,8 +406,9 @@ nav .nav-login {
 }
 
 .project-page.phase-Challenge .progress,
-.hide-challenges .challenge,
 .challenge.hexagon .progress { display: none; }
+.hide-challenges .challenge { opacity: 0.1 !important; }
+
 .challenge.hexagon .hexagontent {
   color: #35a;
   font-weight: normal;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -405,6 +405,17 @@ nav .nav-login {
   transform: scale(1.2);
 }
 
+.hexagon .team-count {
+  top: -2.2em;
+  right: -0.8em;
+  min-width: 2em;
+  position: absolute;
+  color: black;
+  font-size: 80%;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(0, 0, 0, 0.3);
+}
+
 .project-page.phase-Challenge .progress,
 .challenge.hexagon .progress { display: none; }
 .hide-challenges .challenge { opacity: 0.1 !important; }
@@ -1142,6 +1153,7 @@ pre { color: #333; background: white; }
   text-align: center;
   margin-top: 1em;
 }
+.team-count,
 .user-score {
   min-width: 2.5em;
   text-align: center;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -406,14 +406,14 @@ nav .nav-login {
 }
 
 .hexagon .team-count {
-  top: -2.2em;
+  top: -2em;
   right: -0.8em;
   min-width: 2em;
   position: absolute;
   color: black;
   font-size: 80%;
   background: rgba(255, 255, 255, 0.8);
-  border: 1px solid rgba(0, 0, 0, 0.3);
+  border: 1px dashed rgba(0,0,200,0.4);
 }
 
 .project-page.phase-Challenge .progress,

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -1156,6 +1156,7 @@ pre { color: #333; background: white; }
 .profile-projects::-webkit-scrollbar {
   display: none;
 }
+.profile-projects .row .card.challenge,
 .profile-projects .row .card.project {
   height: 8em;
   width: 20em;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -1177,6 +1177,7 @@ pre { color: #333; background: white; }
   border-radius: 20px;
 }
 .profile-projects.honeycomb {
+  min-height: 20em;
   padding: 1.5em 4em;
 }
 .profile-projects::-webkit-scrollbar {

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -995,6 +995,10 @@ pre { color: #333; background: white; }
   margin-right: 15px;
   text-align: right;
 }
+.project-page .project-score {
+  text-align: center;
+  min-width: 8em;
+}
 .project-page .project-category {
   float: right;
   font-size: 110%;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -341,24 +341,20 @@ nav .nav-login {
 /* ---- Hexagonal hawtness ---- */
 
 .event-home .honeycomb {
-  /*margin: 30px 0px 100px 0px;
-  left: 50%;*/
   width: 760px;
+  margin-top: 30px;
 }
-@media (max-width: 980px) {
+@media (max-width: 900px) {
   .event-home .honeycomb {
-    width: auto;
-    /* left: inherit; */
+    margin-top: 0px;
+    width: 600px;
   }
 }
-@media (max-width: 420px) {
-  .event-home .honeycomb .hexagon {
-    /* margin-bottom: auto; */
-    /* top: auto; */
-  }
+@media (max-width: 560px) {
   .event-home .honeycomb {
+    margin-top: 0px;
     text-align: center;
-    clear: both;
+    width: 300px;
   }
 }
 
@@ -459,16 +455,35 @@ nav .nav-login {
 .project .hexagontent .progress-bar {
   background-color: #aaa;
 }
+
+.honeycomb {
+  text-align: left;
+}
 .honeycomb .hexagon {
   opacity: 0.4;
   box-shadow: none;
+  margin: 3px 21px;
+  clear: none;
+}
+.honeycomb .hexagon, .hexagon::before, .honeycomb .hexagon::after {
+  width: 82px;
+  height: 142px;
+}
+.honeycomb .hexagon:nth-child(even) {
+  top: 73px;
+  clear: both;
 }
 .honeycomb .hexagon.category-highlight {
   opacity: 1.0;
   box-shadow: 0 1px 3px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.3);
 }
+.honeycomb .hexagontent {
+  font-size: 1.0rem;
+}
 .honeycomb .hexagon.hexalist {
-  display: none; background: white !important; color: black;
+  display: none;
+  background: white !important;
+  color: black;
 }
 .honeycomb .hexagon.hexalist.category-highlight { display: block; }
 .hexagon.hexalist .hexagontent {

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -396,7 +396,10 @@ nav .nav-login {
 .event-home .hexagon {
   margin-bottom: 4px;
 }
-
+.hexagon.gridfix {
+  visibility: hidden;
+  margin-top: 2em;
+}
 .hexagon:hover {
   box-shadow: 0 4px 9px rgb(0 0 0 / 5%), 0 9px 15px rgb(0 0 0 / 17%);
   transform: scale(1.2);

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -269,22 +269,12 @@ nav .nav-login {
 }
 
 /* Customize the flipclock widget */
-.event-countdown .flip-clock {
+.event-countdown {
   margin-top: 20px;
+  display: inline-block;
 }
-.event-countdown .flip-clock-label {
+.event-countdown .rotor-group-heading {
   display: none;
-}
-@media (max-width: 1200px) {
-  .event-countdown .flip-clock .flip-clock-group * {
-    width: 38px;
-  }
-  .event-countdown .flip-clock {
-    position: relative;
-    left: 50%;
-    width: 360px;
-    margin-left: -180px;
-  }
 }
 @media (max-width: 400px) {
   .event-countdown {
@@ -295,9 +285,6 @@ nav .nav-login {
   width: 100%;
   display: block;
   text-align: center;
-}
-.event-countdown {
-  display: inline-block;
 }
 @media (max-width: 1190px) {
   .event-footer .event-countdown {

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -181,22 +181,22 @@ ul.help-block {
   margin-right: 45px;
 }
 .section-header .section-header-logo img {
-  height: 6em;
+  height: 8em;
   margin-bottom: 2em;
-}
-.section-header .event-hostname,
-.section-header .event-location {
-  font-size: 110%; color: #555;
-  display: inline-block;
-}
-.section-header .event-hostname::before {
-  content: ' - ';
 }
 .section-header .section-header-content div {
   color: initial;
+  font-size: 125%;
+  display: inline-block;
+  margin-right: 1em;
 }
-.section-header .section-header-content .event-date {
-  font-size: 120%;
+.section-header .section-header-content .event-hostname {
+  display: block;
+  font-weight: 600;
+}
+.section-header .section-header-content .fa {
+  opacity: 0.5;
+  width: 1.2em;
 }
 .section-header a:hover {
   text-decoration: none;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -1177,8 +1177,10 @@ pre { color: #333; background: white; }
   border-radius: 20px;
 }
 .profile-projects.honeycomb {
-  min-height: 20em;
   padding: 1.5em 4em;
+  height: 20em;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 .profile-projects::-webkit-scrollbar {
   display: none;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -327,6 +327,10 @@ nav .nav-login {
   text-align: center;
   display: block;
 }
+.event-home .event-info {
+  box-shadow: 3px 3px 0px rgb(0 0 0 / 30%);
+  border: 1px solid rgba(0,0,0,0.3);
+}
 .event-home .event-info .event-summary {
   text-align: center;
   margin: 1em 10%;

--- a/dribdat/static/js/clock.js
+++ b/dribdat/static/js/clock.js
@@ -9,8 +9,9 @@
       var datesched = Date.parse(startdate.replace(' ', 'T'));
       var timeleft = datesched - datenow;
       if (isNaN(timeleft) || timeleft < 0) return;
+      var unixtime = datesched / 1000;
       // Start the clock
-      new FlipDown(datesched, $(this).attr('id')).start();
+      new FlipDown(unixtime, $(this).attr('id')).start();
     });
 
   });

--- a/dribdat/static/js/clock.js
+++ b/dribdat/static/js/clock.js
@@ -9,12 +9,8 @@
       var datesched = Date.parse(startdate.replace(' ', 'T'));
       var timeleft = datesched - datenow;
       if (isNaN(timeleft) || timeleft < 0) return;
-
-      var clock = new FlipClock(this, new Date(datesched), {
-        face: 'DayCounter',
-        countdown: true
-      });
-      // clock.setCountdown(true);
+      // Start the clock
+      new FlipDown(datesched, $(this).attr('id')).start();
     });
 
   });

--- a/dribdat/static/libs/flipclock
+++ b/dribdat/static/libs/flipclock
@@ -1,1 +1,0 @@
-../../../node_modules/flipclock/dist/

--- a/dribdat/static/libs/flipdown
+++ b/dribdat/static/libs/flipdown
@@ -1,0 +1,1 @@
+../../../node_modules/flipdown/dist/

--- a/dribdat/templates/404.html
+++ b/dribdat/templates/404.html
@@ -11,10 +11,9 @@
         <p>I am afraid I can't do that Dave. Would you like to play a game instead?</p><br>
 
         <a href="{{ url_for('public.home') }}" class="btn btn-lg btn-success">
-            Go home
+            Continue on your way home
         </a>
         <a href="https://itch.io/randomizer" class="btn btn-lg btn-light" target="_blank">
-            &#xe12b;
             I'm feeling ludic
         </a>
     </div>

--- a/dribdat/templates/admin/events.html
+++ b/dribdat/templates/admin/events.html
@@ -4,8 +4,8 @@
 <div class="container admin-events">
   <div class="btn-group float-right mb-2">
     <a href="{{ url_for('public.event_new') }}" class="btn btn-success btn-lg">Start an event</a>
-    <button type="button" class="btn btn-dark" data-toggle="modal" data-target="#importEvent">
-      Import</button>
+    <button type="button" class="btn btn-lg btn-dark" data-toggle="modal" data-target="#importEvent">
+      Import data</button>
   </div>
     <h2>Events</h2>
     <table class='table table-hover'>
@@ -107,7 +107,7 @@
           method="post" enctype="multipart/form-data">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="uploadFileLabel">Import Event</h5>
+        <h5 class="modal-title" id="uploadFileLabel">Import Event data</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/dribdat/templates/admin/index.html
+++ b/dribdat/templates/admin/index.html
@@ -29,10 +29,9 @@
 
   <div class="chart-activities">
     <div class="btn-group mb-2 text-center">
-      <a href="{{ url_for('admin.events') }}" class="btn btn-lg btn-warning">All Events</a>
+      <a href="{{ url_for('admin.events') }}" class="btn btn-lg btn-info">Events</a>
       <a href="{{ url_for('admin.projects') }}" class="btn btn-lg btn-info">Projects</a>
       <a href="{{ url_for('admin.users') }}" class="btn btn-lg btn-info">Users</a>
-      <a href="{{ url_for('public.event_start') }}" class="btn btn-lg btn-success">Start an Event</a>
       <!-- <a href="#" id="show-activities" class="btn btn-lg btn-info">Pulse check</a> -->
     </div>
     <div class="container">

--- a/dribdat/templates/includes/header.html
+++ b/dribdat/templates/includes/header.html
@@ -8,14 +8,20 @@
       {% endif %}
       <div class="section-header-content">
         <h3 class="event-name">{{ event.name }}</h3>
+        {% if event.hostname %}
+          <div class="event-hostname">
+            <i class="fa fa-bank"></i>
+            {{ event.hostname }}</div>
+        {% endif %}
         {% if not event.lock_resources %}
-          <div class="event-date">{{ event.date }}</div>
+          <div class="event-date">
+            <i class="fa fa-calendar"></i>
+            {{ event.date }}</div>
         {% endif %}
         {% if event.location %}
-          <div class="event-location">{{ event.location }}</div>
-        {% endif %}
-        {% if event.hostname %}
-          <div class="event-hostname">{{ event.hostname }}</div>
+          <div class="event-location">
+            <i class="fa fa-map"></i>
+            {{ event.location }}</div>
         {% endif %}
       </div>
     </a>

--- a/dribdat/templates/includes/stages.yaml
+++ b/dribdat/templates/includes/stages.yaml
@@ -6,26 +6,26 @@ stages:
   -
     id: 0
     name: CHALLENGE
-    phase: Define
-    description: 🚧 Ask questions and come around the issues that matter
+    phase: Identify
+    description: 🚧 Ask questions to find the data and issues that matter.
     conditions:
       validate:
         -
           field: summary
           min: 5
-          help: Your challenge needs a short summary.
+          help: Your data challenge needs a short summary.
         -
           field: excerpt
           min: 123
-          help: At least 123 characters in the challenge description.
+          help: Please write at least one paragraph (123 chars) in the description.
       agree:
-        - We have formulated our question in a way that hints at what kind of data will be needed. Which in turns helps to scope the project.
-        - The data needed is readily available, acquisition is realistic given our time limits.
+        - The question is formulated in a way that hints at what kind of data will be needed, helping to scope the project.
+        - The data needed is readily available, and acquisition is realistic given our time limits.
   -
     id: 5
     name: NEW
     phase: Find
-    description: 👪 You can’t do much if you can’t find the data!
+    description: 👪 Collecting the necessary resources in a shared space.
     conditions:
       validate:
         -
@@ -38,13 +38,13 @@ stages:
           test: validurl
           help: Provide a download link to your data repository in the Details of your project page.
       agree:
-        - We have a shared collaboration space in which to work on the data.
-        - Our team members will work together for the duration of the event.
+        - Our team members have agreed to work together for the duration of the event.
+        - We have a shared collaboration space (repository) in which to work on the data.
   -
     id: 10
     name: RESEARCHED
     phase: Get
-    description: ⚗️ Scoping of data collection or improvement strategy has been done.
+    description: ⚗️ Scoping of data collection or improvement strategy.
     conditions:
       validate:
         -
@@ -53,12 +53,13 @@ stages:
           help: Provide a source link in your project Details.
       agree:
         - A source code repository has been set up where data quality improvements can be made.
-        - We have considered crowdsourcing, offline data collection, web scraping, etc.
+        - Aggregation (download, mirroring, crowdsourcing, web scraping..) is in progress.
+        - The schema, ontology, and metadata are being elaborated and documented.
   -
     id: 20
     name: SKETCHED
     phase: Verify
-    description: 🎨 The overall details of the dataset have been evaluated
+    description: 🎨 Evaluating and documenting the dataset in more detail.
     conditions:
       validate:
         -
@@ -66,13 +67,14 @@ stages:
           test: validurl
           help: Upload or link to an image in your project Details.
       agree:
-        - Check the meta-data, the methodology of collection, if we know who organised the dataset and it’s a credible source.
-        - Attach a screenshot of the dataset or a simple preview visualization as an image.
+        - Check the metadata and methods behind your data, to learn who organised this, and decide whether they are a credible source.
+        - Annotate the dataset to explain your detailed evaluation of the structure and content.
+        - A screenshot or preview of the dataset is attached as an image.
   -
     id: 30
     name: PROTOTYPED
     phase: Clean
-    description: 🐣 Efforts to improve the quality of the data are in progress.
+    description: 🐣 Efforts to improve the quality of the data.
     conditions:
       validate:
         -
@@ -80,13 +82,14 @@ stages:
           test: validurl
           help: Online access to browse the dataset in the Project Link.
       agree:
-        - We have the rights, open licenses, or permission to use all data, assets and code.
-        - We have the skills and tools that will help us get the data into a machine-readable format and analyse it.
+        - A wide angle view has been gained on the data using a spreadsheet, data wrangling or statistical program.
+        - We have checked the rights, open licenses, and permissions to use all data, assets and code.
+        - The necessary infrastructure for data processing is available to us, and can be maintained.
   -
     id: 40
     name: LAUNCHED
     phase: Analyse
-    description: 🎈 Get insights about the problem we defined in the beginning.
+    description: 🎈 Gaining insights on the problem defined in the beginning.
     conditions:
       validate:
         -
@@ -94,13 +97,14 @@ stages:
           test: validurl
           help: Link and sync a remote repository or README for your project.
       agree:
-        - Explore the data in Python, R, Julia, etc. or use spreadsheets or statistical suites.
+        - Gain depth in a programming language like Julia, Python, D3 or R.
         - Use data visualisations to get insights of different variables.
+        - Correlate and link data fields, with critical reflection of causality.
   -
     id: 50
     name: LIVE
-    phase: Present
-    description: 🚀 Think about the audience, answer questions, make the results and yourself available to the public
+    phase: Communicate
+    description: 🚀 Thinking about audience and making the results public.
     conditions:
       validate:
         -
@@ -108,6 +112,6 @@ stages:
           test: validurl
           help: Provide a working contact link in your project Details.
       agree:
-        - Make sure to attribute and thank all contributors and dependencies.
-        - It is possible to contact the maintainers with questions or feedback.
-        - The full results of our project can be obtained under an open license.
+        - The full results of this work have been showcased and published under an open license.
+        - Contact with the maintainers is possible to ask questions or send feedback.
+        - We have made sure to attribute all sources and thank all contributors.

--- a/dribdat/templates/includes/stages.yaml
+++ b/dribdat/templates/includes/stages.yaml
@@ -7,44 +7,41 @@ stages:
     id: 0
     name: CHALLENGE
     phase: Identify
-    description: 🚧 Ask questions to find the data and issues that matter.
+    description: 🚧 Asking questions with data about issues that matter.
     conditions:
       validate:
         -
           field: summary
           min: 5
-          help: Your data challenge needs a short summary.
+          help: Your challenge should have a short summary.
         -
           field: excerpt
           min: 123
           help: Please write at least one paragraph (123 chars) in the description.
       agree:
-        - The question is formulated in a way that hints at what kind of data will be needed, helping to scope the project.
-        - The data needed is readily available, and acquisition is realistic given our time limits.
+        - Questions are formulated in a way that hint at what data will be needed, helping to scope the project.
+        - Links to readily available data sources and other resources have been provided.
+        - Acquiring data to meet the challenge is realistic within our time limits.
   -
     id: 5
     name: NEW
     phase: Find
-    description: 👪 Collecting the necessary resources in a shared space.
+    description: 👪 Collecting resources together in a shared space.
     conditions:
       validate:
         -
           field: team
           min: 1
           max: 5
-          help: Between 1 and 5 people should join your data expedition.
-        -
-          field: download_url
-          test: validurl
-          help: Provide a download link to your data repository in the Details of your project page.
+          help: Between 1 and 5 people should join your project or data expedition.
       agree:
         - Our team members have agreed to work together for the duration of the event.
-        - We have a shared collaboration space (repository) in which to work on the data.
+        - We are collecting data, and sharing it in an accessible collaboration space.
   -
     id: 10
     name: RESEARCHED
     phase: Get
-    description: ⚗️ Scoping of data collection or improvement strategy.
+    description: ⚗️ Scoping of data collection and prototyping strategy.
     conditions:
       validate:
         -
@@ -52,14 +49,14 @@ stages:
           test: validurl
           help: Provide a source link in your project Details.
       agree:
-        - A source code repository has been set up where data quality improvements can be made.
-        - Aggregation (download, mirroring, crowdsourcing, web scraping..) is in progress.
-        - The schema, ontology, and metadata are being elaborated and documented.
+        - A shared repository has been set up where work on code and data can be tracked.
+        - Aggregation of data (download, crowdsourcing, scraping, etc.) is in progress.
+        - Link any relevant data schema or code frameworks in your documentation.
   -
     id: 20
     name: SKETCHED
     phase: Verify
-    description: 🎨 Evaluating and documenting the dataset in more detail.
+    description: 🎨 Evaluating and explaining to fellow humans.
     conditions:
       validate:
         -
@@ -67,24 +64,23 @@ stages:
           test: validurl
           help: Upload or link to an image in your project Details.
       agree:
-        - Check the metadata and methods behind your data, to learn who organised this, and decide whether they are a credible source.
-        - Annotate the dataset to explain your detailed evaluation of the structure and content.
-        - A screenshot or preview of the dataset is attached as an image.
+        - Check the metadata and methods of your data, decide whether they come from a credible source.
+        - Annotate key datasets to explain your understanding of the structure and content.
+        - We made wireframes or sketches of our idea, attaching it here as an image.
   -
     id: 30
     name: PROTOTYPED
     phase: Clean
-    description: 🐣 Efforts to improve the quality of the data.
+    description: 🐣 Efforts to improve the quality of the output.
     conditions:
       validate:
         -
           field: webpage_url
           test: validurl
-          help: Online access to browse the dataset in the Project Link.
+          help: Online access to browse your data or demo in the Project Link.
       agree:
-        - A wide angle view has been gained on the data using a spreadsheet, data wrangling or statistical program.
-        - We have checked the rights, open licenses, and permissions to use all data, assets and code.
-        - The necessary infrastructure for data processing is available to us, and can be maintained.
+        - We have checked the rights, open licenses, and permissions to use all assets, data, and code.
+        - Perspective was gained on the data using a spreadsheet, data wrangling or statistical program.
   -
     id: 40
     name: LAUNCHED
@@ -97,9 +93,9 @@ stages:
           test: validurl
           help: Link and sync a remote repository or README for your project.
       agree:
-        - Gain depth in a programming language like Julia, Python, D3 or R.
-        - Use data visualisations to get insights of different variables.
-        - Correlate and link data fields, with critical reflection of causality.
+        - Gain more depth by exploring data in code, with data visualisations and interfaces.
+        - While correlating and linking data fields, we made critical reflection of causality.
+        - The necessary infrastructure for hosting is available, and can be maintained.
   -
     id: 50
     name: LIVE
@@ -110,8 +106,12 @@ stages:
         -
           field: contact_url
           test: validurl
-          help: Provide a working contact link in your project Details.
+          help: Provide a contact link in your project Details.
+        -
+          field: download_url
+          test: validurl
+          help: Provide a download link in your project Details.
       agree:
         - The full results of this work have been showcased and published under an open license.
         - Contact with the maintainers is possible to ask questions or send feedback.
-        - We have made sure to attribute all sources and thank all contributors.
+        - We have made sure to attribute all sources, and to thank all contributors.

--- a/dribdat/templates/includes/stages.yaml
+++ b/dribdat/templates/includes/stages.yaml
@@ -6,8 +6,8 @@ stages:
   -
     id: 0
     name: CHALLENGE
-    phase: Challenge
-    description: 🚧 This is an idea or challenge description
+    phase: Define
+    description: 🚧 Ask questions and come around the issues that matter
     conditions:
       validate:
         -
@@ -17,34 +17,34 @@ stages:
         -
           field: excerpt
           min: 123
-          help: At least 123 characters in the challenge pitch.
+          help: At least 123 characters in the challenge description.
       agree:
-        - The challenge is well documented, with links to resources and contacts.
-        - We accept this challenge as realistic in the time limits of the event.
+        - We have formulated our question in a way that hints at what kind of data will be needed. Which in turns helps to scope the project.
+        - The data needed is readily available, acquisition is realistic given our time limits.
   -
     id: 5
     name: NEW
-    phase: Researching
-    description: 👪 A team has formed and started a project
+    phase: Find
+    description: 👪 You can’t do much if you can’t find the data!
     conditions:
       validate:
         -
           field: team
           min: 1
           max: 5
-          help: Between 1 and 5 members need to join your project.
+          help: Between 1 and 5 people should join your data expedition.
         -
-          field: contact_url
+          field: download_url
           test: validurl
-          help: Provide a contact link in the Details of your project page.
+          help: Provide a download link to your data repository in the Details of your project page.
       agree:
-        - We have a shared channel or working area in which to collaborate.
+        - We have a shared collaboration space in which to work on the data.
         - Our team members will work together for the duration of the event.
   -
     id: 10
     name: RESEARCHED
-    phase: Sketching
-    description: ⚗️ Scoping research has been done and documented
+    phase: Get
+    description: ⚗️ Scoping of data collection or improvement strategy has been done.
     conditions:
       validate:
         -
@@ -52,13 +52,13 @@ stages:
           test: validurl
           help: Provide a source link in your project Details.
       agree:
-        - A source code repository or shared folder has been set up and shared.
-        - We have defined the scope of the project, and have documented our goals.
+        - A source code repository has been set up where data quality improvements can be made.
+        - We have considered crowdsourcing, offline data collection, web scraping, etc.
   -
     id: 20
     name: SKETCHED
-    phase: Prototyping
-    description: 🎨 Initial designs have been sketched and shared
+    phase: Verify
+    description: 🎨 The overall details of the dataset have been evaluated
     conditions:
       validate:
         -
@@ -66,27 +66,27 @@ stages:
           test: validurl
           help: Upload or link to an image in your project Details.
       agree:
-        - Everyone on the team was able to contribute something to the design.
-        - We used a wireframing tool, or just paper, to sketch and share our idea.
+        - Check the meta-data, the methodology of collection, if we know who organised the dataset and it’s a credible source.
+        - Attach a screenshot of the dataset or a simple preview visualization as an image.
   -
     id: 30
     name: PROTOTYPED
-    phase: Launching
-    description: 🐣 A prototype of the idea has been developed
+    phase: Clean
+    description: 🐣 Efforts to improve the quality of the data are in progress.
     conditions:
       validate:
         -
           field: webpage_url
           test: validurl
-          help: Provide a project link to an online demo, embedded if possible.
+          help: Online access to browse the dataset in the Project Link.
       agree:
-        - Contributions from outside of our team do not include any major functionality.
         - We have the rights, open licenses, or permission to use all data, assets and code.
+        - We have the skills and tools that will help us get the data into a machine-readable format and analyse it.
   -
     id: 40
     name: LAUNCHED
-    phase: Promoting
-    description: 🎈 The prototype has been deployed and presented
+    phase: Analyse
+    description: 🎈 Get insights about the problem we defined in the beginning.
     conditions:
       validate:
         -
@@ -94,19 +94,20 @@ stages:
           test: validurl
           help: Link and sync a remote repository or README for your project.
       agree:
-        - Any third-party data, assets or software are correctly attributed.
-        - We have thanked every team member, contributor, and mentor.
+        - Explore the data in Python, R, Julia, etc. or use spreadsheets or statistical suites.
+        - Use data visualisations to get insights of different variables.
   -
     id: 50
     name: LIVE
-    phase: Supporting
-    description: 🚀 This project is live and available to the public
+    phase: Present
+    description: 🚀 Think about the audience, answer questions, make the results and yourself available to the public
     conditions:
       validate:
         -
-          field: download_url
+          field: contact_url
           test: validurl
-          help: Provide a working download link in your project Details.
+          help: Provide a working contact link in your project Details.
       agree:
-        - The full results of our project can be obtained under an open license.
+        - Make sure to attribute and thank all contributors and dependencies.
         - It is possible to contact the maintainers with questions or feedback.
+        - The full results of our project can be obtained under an open license.

--- a/dribdat/templates/layout.html
+++ b/dribdat/templates/layout.html
@@ -34,11 +34,11 @@
 
   {% if config.ENV == 'prod' %}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@4/dist/{{ config.DRIBDAT_THEME }}/bootstrap.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flipclock@0/dist/flipclock.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flipdown@0/dist/flipdown.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/font-awesome@4/css/font-awesome.min.css">
   {% else %}
   <link rel="stylesheet" href="{{ url_for('static', filename='libs/bootswatch/' + config.DRIBDAT_THEME + '/bootstrap.css')}}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='libs/flipclock/flipclock.css')}}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='libs/flipdown/flipdown.css')}}">
   <link rel="stylesheet" href="{{ url_for('static', filename='libs/font-awesome/css/font-awesome.css')}}">
   {% endif %}
 
@@ -90,12 +90,12 @@
 {% if config.ENV == 'prod' %}
   <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/jquery-resizable-dom@0/dist/jquery-resizable.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/flipclock@0/dist/flipclock.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/flipdown@0/dist/flipdown.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4/dist/js/bootstrap.bundle.min.js"></script>
 {% else %}
   <script src="{{ url_for('static', filename='libs/jquery/jquery.js')}}"></script>
   <script src="{{ url_for('static', filename='libs/jquery-resizable/jquery-resizable.js') }}"></script>
-  <script src="{{ url_for('static', filename='libs/flipclock/flipclock.js')}}"></script>
+  <script src="{{ url_for('static', filename='libs/flipdown/flipdown.js')}}"></script>
   <script src="{{ url_for('static', filename='libs/bootstrap/bootstrap.bundle.js')}}"></script>
 {% endif %}
 {% assets "js_all" %}

--- a/dribdat/templates/macros/_event.html
+++ b/dribdat/templates/macros/_event.html
@@ -2,7 +2,7 @@
 <!-- Based on Hexagon Tiles by Graham Pyne http://codepen.io/gpyne/pen/iElhp/ -->
 	<a href="{{ url_for('project.project_view', project_id=project.id) }}"
 		 title="{{ project.summary }}"
-		 class="hexagon {{ 'challenge' if project.phase=='Challenge' else 'project' }} category-highlight"
+		 class="hexagon {{ 'challenge' if project.is_challenge else 'project' }} category-highlight"
 		 category-id="{{ project.category_id }}"
 		 style="border-bottom-color:{{project.logo_color}}">
 		<div class="hexagontent{{ ' with-icon' if project.logo_icon }}">
@@ -24,7 +24,7 @@
 {% endmacro %}
 
 {% macro render_project_card(project) %}
-	<a class="col-md-5 ms-auto card project"
+	<a class="col-md-5 ms-auto card {{ 'challenge' if project.is_challenge else 'project' }}"
 		 href="{{ url_for('project.project_view', project_id=project.id) }}">
 
 		{% if project.image_url %}

--- a/dribdat/templates/macros/_event.html
+++ b/dribdat/templates/macros/_event.html
@@ -1,15 +1,17 @@
 {% macro render_project_hexagon(project) %}
 <!-- Based on Hexagon Tiles by Graham Pyne http://codepen.io/gpyne/pen/iElhp/ -->
 	<a href="{{ url_for('project.project_view', project_id=project.id) }}"
-		 title="{{ project.summary }}"
 		 class="hexagon {{ 'challenge' if project.is_challenge else 'project' }} category-highlight"
 		 category-id="{{ project.category_id }}"
 		 style="border-bottom-color:{{project.logo_color}}">
 		<div class="hexagontent{{ ' with-icon' if project.logo_icon }}">
+			{% if project.team %}
+				<span class="team-count" title="# count of members">{{ project.team|count }}</span>
+			{% endif %}
 			{% if project.logo_icon %}
 				<i class="fa fa-{{project.logo_icon}}"></i><br>
 			{% endif %}
-			<span>{{ project.name|truncate(32, True, '..') }}</span>
+			<span title="{{ project.summary }}">{{ project.name|truncate(32, True, '..') }}</span>
 			{% if project.image_url %}
 				<div class="hexaicon" style="background-image:url('{{project.image_url}}')"></div>
 			{% endif %}

--- a/dribdat/templates/macros/_event.html
+++ b/dribdat/templates/macros/_event.html
@@ -1,5 +1,5 @@
-{% macro render_project_hexagon(project) %}
 <!-- Based on Hexagon Tiles by Graham Pyne http://codepen.io/gpyne/pen/iElhp/ -->
+{% macro render_project_hexagon(project) %}
 	<a href="{{ url_for('project.project_view', project_id=project.id) }}"
 		 class="hexagon {{ 'challenge' if project.is_challenge else 'project' }} category-highlight"
 		 category-id="{{ project.category_id }}"

--- a/dribdat/templates/macros/_event.html
+++ b/dribdat/templates/macros/_event.html
@@ -6,7 +6,7 @@
 		 style="border-bottom-color:{{project.logo_color}}">
 		<div class="hexagontent{{ ' with-icon' if project.logo_icon }}">
 			{% if project.is_challenge and project.team %}
-				<span class="team-count" title="# count of members">{{ project.team|count }}</span>
+				<span class="team-count" title="# following">{{ project.team|count }}</span>
 			{% endif %}
 			{% if project.logo_icon %}
 				<i class="fa fa-{{project.logo_icon}}"></i><br>

--- a/dribdat/templates/macros/_event.html
+++ b/dribdat/templates/macros/_event.html
@@ -5,7 +5,7 @@
 		 category-id="{{ project.category_id }}"
 		 style="border-bottom-color:{{project.logo_color}}">
 		<div class="hexagontent{{ ' with-icon' if project.logo_icon }}">
-			{% if project.team %}
+			{% if project.is_challenge and project.team %}
 				<span class="team-count" title="# count of members">{{ project.team|count }}</span>
 			{% endif %}
 			{% if project.logo_icon %}

--- a/dribdat/templates/public/dashboard.html
+++ b/dribdat/templates/public/dashboard.html
@@ -7,7 +7,7 @@
 {% block content %}
 
 <script src="https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/flipclock@0/dist/flipclock.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flipdown@0/dist/flipdown.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4/dist/js/bootstrap.bundle.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery-resizable-dom@0.35.0/dist/jquery-resizable.min.js"></script>
 
@@ -44,7 +44,7 @@
       </div>
 
       {% if current_event.countdown %}
-        <div class="event-countdown" data-start="{{ current_event.countdown }}"></div>
+        <div id="clockDashboard" class="event-countdown flipdown" data-start="{{ current_event.countdown }}"></div>
       {% endif %}
     </main>
 

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -58,8 +58,8 @@
   {% for project in projects %}
     {{ misc.render_project_hexagon(project) }}
   {% endfor %}
-  {% if project_count % 6 != 0 %}
-    <a class="hexagon" style="visibility:hidden"></a>
+  {% if project_count > 6 and project_count % 3 == 0 %}
+    <a class="hexagon gridfix {{ 'float-left' if project_count % 2 != 0 }}"></a>
   {% endif %}
   </div>
 </div><!-- /honeycomb -->

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -52,15 +52,12 @@
 </center>
 
 
-<div class="honeycomb mb-5">
+<div class="honeycomb mb-5 {% if project_count < 7 %}text-center{% endif %}">
   <a name="projects"></a>
   <div class="ibws-fix">
   {% for project in projects %}
     {{ misc.render_project_hexagon(project) }}
   {% endfor %}
-  {% if project_count > 6 and project_count % 2 != 0 %}
-    <a class="hexagon gridfix {{ 'float-left' if project_count % 6 >= 3 }}"></a>
-  {% endif %}
   </div>
 </div><!-- /honeycomb -->
 

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -188,7 +188,7 @@
 
   {% if current_event and current_event.countdown and not 'off' in config.DRIBDAT_CLOCK %}
     <a class="container-countdown" href="#top" title="{{ current_event.countdown }}">
-      <div class="event-countdown" data-start="{{ current_event.countdown }}"></div>
+      <div id="clockEvent" class="event-countdown flipdown" data-start="{{ current_event.countdown }}"></div>
     </a>
   {% endif %}
 </center>

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -58,8 +58,8 @@
   {% for project in projects %}
     {{ misc.render_project_hexagon(project) }}
   {% endfor %}
-  {% if project_count > 6 and project_count % 3 == 0 %}
-    <a class="hexagon gridfix {{ 'float-left' if project_count % 2 != 0 }}"></a>
+  {% if project_count > 6 and project_count % 2 != 0 %}
+    <a class="hexagon gridfix {{ 'float-left' if project_count % 6 >= 3 }}"></a>
   {% endif %}
   </div>
 </div><!-- /honeycomb -->

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -106,7 +106,7 @@
 {% endif %}
 
 {% if current_event.description %}
-<div class="event-info">
+<div class="event-info mt-2 mb-2">
   <div class="content">
     <a name="info"></a>
     <div class="event-description">
@@ -117,7 +117,7 @@
 {% endif %}
 
 {% if current_event.instruction %}
-<div class="jumbotron event-instruction mt-2 mb-2">
+<div class="jumbotron event-instruction mt-4 mb-2">
   <div class="content">
     {{current_event.instruction|markdown}}
   </div>

--- a/dribdat/templates/public/eventprint.html
+++ b/dribdat/templates/public/eventprint.html
@@ -33,7 +33,7 @@
         {% endif %}
         <li>Team:
           <ul class="project-team" title="team">
-          {% for user in project.team() %}
+          {% for user in project.team %}
             <li><a href="{{user.webpage_url}}" target="_blank">{{ user.username }}</a></li>
           {% endfor %}
           </ul>

--- a/dribdat/templates/public/eventstart.html
+++ b/dribdat/templates/public/eventstart.html
@@ -7,8 +7,8 @@
 
 {% block content %}
 <div class="container">
-  <h1>&#128203; Get started</h1>
-  <div class="jumbotron alert alert-info">
+  <h1 class="huge">Get started</h1>
+  <div class="jumbotron alert alert-light">
     <!-- <a class="close" title="Close" href="#" data-dismiss="alert">&times;</a> -->
     <div class="container scroll-after-500">
       {{ tips|markdown }}

--- a/dribdat/templates/public/home.html
+++ b/dribdat/templates/public/home.html
@@ -25,7 +25,7 @@
       <a class="container-countdown"
         href="{{ url_for('public.event', event_id=current_event.id) }}"
         title="{{ current_event.countdown }}">
-        <div class="event-countdown" data-start="{{ current_event.countdown }}"></div>
+        <div id="clockTop" class="event-countdown flipdown" data-start="{{ current_event.countdown }}"></div>
       </a>
     {% endif %}
     <div class="home-description">
@@ -72,7 +72,7 @@
       <a class="container-countdown"
          href="{{ url_for('public.event', event_id=current_event.id) }}"
          title="{{ current_event.countdown }}">
-        <div class="event-countdown" data-start="{{ current_event.countdown }}"></div>
+        <div id="clockDown" class="event-countdown flipdown" data-start="{{ current_event.countdown }}"></div>
       </a>
     {% endif %}
   </div><!-- /.jumbotron -->

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -624,10 +624,13 @@ class Project(PkModel):
             content_license = "https://creativecommons.org/licenses/by/4.0/"
         else:
             content_license = ''
+        cleansummary = None
+        if self.summary:
+            cleansummary = re.sub('<[^>]*>', '', self.summary)
         return {
             "@type": "CreativeWork",
             "name": self.name,
-            "description": re.sub('<[^>]*>', '', self.summary),
+            "description": cleansummary,
             "dateCreated": format_date(self.created_at, '%Y-%m-%dT%H:%M'),
             "dateUpdated": format_date(self.updated_at, '%Y-%m-%dT%H:%M'),
             "discussionUrl": self.contact_url,

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -463,7 +463,7 @@ class Project(PkModel):
         q = q.order_by(Activity.timestamp.desc())
         return q.limit(max)
 
-    def team(self):
+    def get_team(self):
         """ Return all starring users (A team) """
         activities = Activity.query.filter_by(
             name='star', project_id=self.id
@@ -473,6 +473,11 @@ class Project(PkModel):
             if a.user and a.user not in members and a.user.active:
                 members.append(a.user)
         return members
+
+    @property
+    def team(self):
+        """ Array of project team """
+        return [u.username for u in self.get_team()]
 
     def all_dribs(self):
         """ Query which formats the project's timeline """
@@ -576,6 +581,7 @@ class Project(PkModel):
             'id': self.id,
             'url': self.url,
             'name': self.name,
+            'team': self.team,
             'score': self.score,
             'phase': self.phase,
             'is_challenge': self.is_challenge,
@@ -594,7 +600,6 @@ class Project(PkModel):
         }
         d['created_at'] = format_date(self.created_at, '%Y-%m-%dT%H:%M')
         d['updated_at'] = format_date(self.updated_at, '%Y-%m-%dT%H:%M')
-        d['team'] = [u.username for u in self.team()]
         # Generate excerpt based on summary data
         if self.longtext and len(self.longtext) > 10:
             d['excerpt'] = self.longtext[:MAX_EXCERPT_LENGTH]

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -427,7 +427,8 @@ class Project(PkModel):
 
     is_hidden = Column(db.Boolean(), default=False)
     is_webembed = Column(db.Boolean(), default=False)
-    is_autoupdate = Column(db.Boolean(), default=True) # remotely managed (by bot)
+    # remotely managed (by bot)
+    is_autoupdate = Column(db.Boolean(), default=True)
 
     autotext = Column(db.UnicodeText(), nullable=True, default=u"")
     longtext = Column(db.UnicodeText(), nullable=False, default=u"")
@@ -480,7 +481,7 @@ class Project(PkModel):
                     ).order_by(Activity.timestamp.desc())
         dribs = []
         prev = None
-        only_active = False # show dribs from inactive users
+        only_active = False  # show dribs from inactive users
         for a in activities:
             a_parsed = getActivityByType(a, only_active)
             if a_parsed is None:
@@ -577,6 +578,7 @@ class Project(PkModel):
             'name': self.name,
             'score': self.score,
             'phase': self.phase,
+            'is_challenge': self.is_challenge,
             'progress': self.progress,
             'summary': self.summary or '',
             'hashtag': self.hashtag or '',
@@ -638,8 +640,8 @@ class Project(PkModel):
         self.name = data['name']
         self.summary = data['summary']
         self.hashtag = data['hashtag']
-        self.score = data['score']
-        self.progress = data['progress']
+        self.score = int(data['score'])
+        self.progress = int(data['progress'])
         self.image_url = data['image_url']
         self.source_url = data['source_url']
         self.webpage_url = data['webpage_url']

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@toast-ui/editor": "^3",
     "bootstrap": "^4",
     "bootswatch": "^4",
-    "flipclock": "^0",
+    "flipdown": "^0.3.2",
     "font-awesome": "^4",
     "jquery": "^3",
     "jquery-resizable-dom": "^0",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "private": false,
   "dependencies": {
     "@toast-ui/editor": "^3",
-    "bootstrap": "^4.3.1",
-    "bootswatch": "^4.5.2",
-    "flipclock": "^0.10.5",
-    "font-awesome": "^4.7.0",
-    "jquery": "^3.4.1",
-    "jquery-resizable-dom": "^0.35.0",
-    "popper.js": "^1.16.1"
+    "bootstrap": "^4",
+    "bootswatch": "^4",
+    "flipclock": "^0",
+    "font-awesome": "^4",
+    "jquery": "^3",
+    "jquery-resizable-dom": "^0",
+    "popper.js": "^1"
   }
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -320,7 +320,7 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "12.3.0"
+version = "12.3.3"
 description = "Faker is a Python package that generates fake data for you."
 category = "dev"
 optional = false
@@ -417,7 +417,7 @@ flake8 = "*"
 
 [[package]]
 name = "flask"
-version = "2.0.2"
+version = "2.0.3"
 description = "A simple framework for building complex web applications."
 category = "main"
 optional = false
@@ -1386,7 +1386,7 @@ test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.0"
+version = "4.1.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
@@ -1780,8 +1780,8 @@ factory-boy = [
     {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
 ]
 faker = [
-    {file = "Faker-12.3.0-py3-none-any.whl", hash = "sha256:b996c2162448241a48155df2077458d6fcf1adcee9a6d1201bb9c06c40e8f48d"},
-    {file = "Faker-12.3.0.tar.gz", hash = "sha256:e1939ea638e7bacfa4dce69f872bdd7d53c1b23a92f1bd9f530590c93a4677e0"},
+    {file = "Faker-12.3.3-py3-none-any.whl", hash = "sha256:a7244b7f25503811072122d98918f445df276ea80c5e38448f51a3b765665ece"},
+    {file = "Faker-12.3.3.tar.gz", hash = "sha256:dc46ddaf9bd33998c49c69dc68273bb5b11e41820b38f05296d3241c7d681597"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -1810,8 +1810,8 @@ flake8-quotes = [
     {file = "flake8-quotes-3.3.1.tar.gz", hash = "sha256:633adca6fb8a08131536af0d750b44d6985b9aba46f498871e21588c3e6f525a"},
 ]
 flask = [
-    {file = "Flask-2.0.2-py3-none-any.whl", hash = "sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a"},
-    {file = "Flask-2.0.2.tar.gz", hash = "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2"},
+    {file = "Flask-2.0.3-py3-none-any.whl", hash = "sha256:59da8a3170004800a2837844bfa84d49b022550616070f7cb1a659682b2e7c9f"},
+    {file = "Flask-2.0.3.tar.gz", hash = "sha256:e1120c228ca2f553b470df4a5fa927ab66258467526069981b3eb0a91902687d"},
 ]
 flask-assets = [
     {file = "Flask-Assets-2.0.tar.gz", hash = "sha256:1dfdea35e40744d46aada72831f7613d67bf38e8b20ccaaa9e91fdc37aa3b8c2"},
@@ -2421,8 +2421,8 @@ typer = [
     {file = "typer-0.4.0.tar.gz", hash = "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.1.0-py3-none-any.whl", hash = "sha256:c13180fbaa7cd97065a4915ceba012bdb31dc34743e63ddee16360161d358414"},
-    {file = "typing_extensions-4.1.0.tar.gz", hash = "sha256:ba97c5143e5bb067b57793c726dd857b1671d4b02ced273ca0538e71ff009095"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -6,20 +6,14 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-tz = ["python-dateutil"]
-
 [package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.9\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
 Mako = "*"
 SQLAlchemy = ">=1.3.0"
 
-[package.dependencies.importlib-metadata]
-version = "*"
-python = "<3.9"
-
-[package.dependencies.importlib-resources]
-version = "*"
-python = "<3.9"
+[package.extras]
+tz = ["python-dateutil"]
 
 [[package]]
 name = "aniso8601"
@@ -39,7 +33,6 @@ description = "Atomic file writes."
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-marker = "sys_platform == \"win32\""
 
 [[package]]
 name = "attrs"
@@ -50,10 +43,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bcrypt"
@@ -63,13 +56,13 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-tests = ["pytest (>=3.2.1,<3.3.0 || >3.3.0)"]
-typecheck = ["mypy"]
-
 [package.dependencies]
 cffi = ">=1.1"
 six = ">=1.4.1"
+
+[package.extras]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
+typecheck = ["mypy"]
 
 [[package]]
 name = "beautifulsoup4"
@@ -79,12 +72,12 @@ category = "dev"
 optional = false
 python-versions = ">3.0.0"
 
+[package.dependencies]
+soupsieve = ">1.2"
+
 [package.extras]
 html5lib = ["html5lib"]
 lxml = ["lxml"]
-
-[package.dependencies]
-soupsieve = ">1.2"
 
 [[package]]
 name = "bleach"
@@ -115,13 +108,13 @@ category = "main"
 optional = false
 python-versions = ">= 3.6"
 
-[package.extras]
-crt = ["botocore (>=1.21.0,<2.0a0)"]
-
 [package.dependencies]
 botocore = ">=1.22.12,<1.23.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.5.0,<0.6.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
@@ -131,13 +124,13 @@ category = "main"
 optional = false
 python-versions = ">= 3.6"
 
-[package.extras]
-crt = ["awscrt (0.12.5)"]
-
 [package.dependencies]
 jmespath = ">=0.7.1,<1.0.0"
 python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.12.5)"]
 
 [[package]]
 name = "certifi"
@@ -168,12 +161,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.11"
+version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
 python-versions = ">=3.5.0"
-marker = "python_version >= \"3\""
 
 [package.extras]
 unicode_backport = ["unicodedata2"]
@@ -187,11 +179,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-colorama = "*"
-
-[package.dependencies.importlib-metadata]
-version = "*"
-python = "<3.8"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -220,16 +209,16 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+cffi = ">=1.12"
+
 [package.extras]
-docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0,<3.1.0 || >3.1.0,<3.1.1 || >3.1.1)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
-
-[package.dependencies]
-cffi = ">=1.12"
+test = ["pytest (>=6.2.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "cssmin"
@@ -249,12 +238,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "dataclasses"
-version = "0.6"
+version = "0.8"
 description = "A backport of the dataclasses module for Python 3.6"
 category = "main"
 optional = false
-python-versions = "*"
-marker = "python_version < \"3.7\""
+python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "decorator"
@@ -272,11 +260,11 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
-[package.extras]
-dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
-
 [package.dependencies]
 wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "dnspython"
@@ -323,12 +311,12 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+Faker = ">=0.7.0"
+
 [package.extras]
 dev = ["coverage", "django", "flake8", "isort", "pillow", "sqlalchemy", "mongoengine", "wheel (>=0.32.0)", "tox", "zest.releaser"]
 doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
-
-[package.dependencies]
-Faker = ">=0.7.0"
 
 [[package]]
 name = "faker"
@@ -340,10 +328,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
-
-[package.dependencies.typing-extensions]
-version = ">=3.10.0.2"
-python = "<3.8"
+typing-extensions = {version = ">=3.10.0.2", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "flake8"
@@ -354,13 +339,10 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+importlib-metadata = {version = "<4.3", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
-
-[package.dependencies.importlib-metadata]
-version = "<4.3"
-python = "<3.8"
 
 [[package]]
 name = "flake8-blind-except"
@@ -369,9 +351,6 @@ description = "A flake8 extension that checks for blind except: statements"
 category = "dev"
 optional = false
 python-versions = "*"
-
-[package.dependencies]
-setuptools = "*"
 
 [[package]]
 name = "flake8-debugger"
@@ -406,13 +385,13 @@ category = "dev"
 optional = false
 python-versions = "*"
 
-[package.extras]
-test = ["pytest-cov"]
-
 [package.dependencies]
 flake8 = ">=3.2.1,<5"
 isort = ">=4.3.5,<6"
 testfixtures = ">=6.8.0,<7"
+
+[package.extras]
+test = ["pytest-cov"]
 
 [[package]]
 name = "flake8-polyfill"
@@ -444,15 +423,15 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-async = ["asgiref (>=3.2)"]
-dotenv = ["python-dotenv"]
-
 [package.dependencies]
 click = ">=7.1.2"
 itsdangerous = ">=2.0"
 Jinja2 = ">=3.0"
 Werkzeug = ">=2.0"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
 
 [[package]]
 name = "flask-assets"
@@ -509,10 +488,6 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-signals = ["blinker"]
-sqla = ["sqlalchemy (>=1.3.11)"]
-
 [package.dependencies]
 Flask = ">=1.0.4"
 oauthlib = "*"
@@ -520,6 +495,10 @@ requests = ">=2.0"
 requests-oauthlib = ">=1.0.0"
 urlobject = "*"
 Werkzeug = "<2.1"
+
+[package.extras]
+signals = ["blinker"]
+sqla = ["sqlalchemy (>=1.3.11)"]
 
 [[package]]
 name = "flask-debugtoolbar"
@@ -613,13 +592,13 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-email = ["email-validator"]
-
 [package.dependencies]
 Flask = "*"
 itsdangerous = "*"
 WTForms = "*"
+
+[package.extras]
+email = ["email-validator"]
 
 [[package]]
 name = "frictionless"
@@ -628,6 +607,22 @@ description = "Data management framework for Python that provides functionality 
 category = "main"
 optional = false
 python-versions = "*"
+
+[package.dependencies]
+chardet = ">=3.0"
+isodate = ">=0.6"
+jsonschema = ">=2.5"
+marko = ">=1.0"
+petl = ">=1.6"
+python-dateutil = ">=2.8"
+python-slugify = ">=1.2"
+pyyaml = ">=5.3"
+requests = ">=2.10"
+rfc3986 = ">=1.4"
+simpleeval = ">=0.9.11"
+stringcase = ">=1.2"
+typer = {version = ">=0.4", extras = ["all"]}
+validators = ">=0.18"
 
 [package.extras]
 bigquery = ["google-api-python-client (>=1.12.1)"]
@@ -643,25 +638,6 @@ s3 = ["boto3 (>=1.9)"]
 server = ["gunicorn (>=20.0)", "flask (>=1.1)"]
 spss = ["savReaderWriter (>=3.0)"]
 sql = ["sqlalchemy (>=1.3)"]
-
-[package.dependencies]
-chardet = ">=3.0"
-isodate = ">=0.6"
-jsonschema = ">=2.5"
-marko = ">=1.0"
-petl = ">=1.6"
-python-dateutil = ">=2.8"
-python-slugify = ">=1.2"
-pyyaml = ">=5.3"
-requests = ">=2.10"
-rfc3986 = ">=1.4"
-simpleeval = ">=0.9.11"
-stringcase = ">=1.2"
-validators = ">=0.18"
-
-[package.dependencies.typer]
-version = ">=0.4"
-extras = ["all"]
 
 [[package]]
 name = "future"
@@ -679,14 +655,14 @@ category = "main"
 optional = false
 python-versions = "*"
 
-[package.extras]
-dev = ["black (19.10b0)", "flake8 (>=3.7,<4)", "pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (2021.1)", "iso8601 (>=0.1,<2)"]
-test = ["pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (2021.1)", "iso8601 (>=0.1,<2)"]
-
 [package.dependencies]
 aniso8601 = ">=8,<10"
 graphql-core = ">=3.1.2,<3.2.0"
 graphql-relay = ">=3.0,<4"
+
+[package.extras]
+dev = ["black (==19.10b0)", "flake8 (>=3.7,<4)", "pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (==2021.1)", "iso8601 (>=0.1,<2)"]
+test = ["pytest (>=5.3,<6)", "pytest-benchmark (>=3.2,<4)", "pytest-cov (>=2.8,<3)", "pytest-mock (>=2,<3)", "pytest-asyncio (>=0.10,<2)", "snapshottest (>=0.5,<1)", "coveralls (>=1.11,<2)", "promise (>=2.3,<3)", "mock (>=4.0,<5)", "pytz (==2021.1)", "iso8601 (>=0.1,<2)"]
 
 [[package]]
 name = "graphql-core"
@@ -706,10 +682,7 @@ python-versions = ">=3.6,<4"
 
 [package.dependencies]
 graphql-core = ">=3.1,<3.2"
-
-[package.dependencies.typing-extensions]
-version = ">=4,<5"
-python = "<3.8"
+typing-extensions = {version = ">=4,<5", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "greenlet"
@@ -736,9 +709,6 @@ gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
 tornado = ["tornado (>=0.2)"]
 
-[package.dependencies]
-setuptools = ">=3.0"
-
 [[package]]
 name = "hiredis"
 version = "2.0.0"
@@ -762,18 +732,14 @@ description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.6"
-marker = "python_version < \"3.9\""
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
-
-[package.dependencies]
-zipp = ">=0.5"
-
-[package.dependencies.typing-extensions]
-version = ">=3.6.4"
-python = "<3.8"
 
 [[package]]
 name = "importlib-resources"
@@ -782,16 +748,13 @@ description = "Read resources from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.6"
-marker = "python_version < \"3.9\""
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
-
-[package.dependencies]
-[package.dependencies.zipp]
-version = ">=3.1.0"
-python = "<3.10"
 
 [[package]]
 name = "iniconfig"
@@ -841,11 +804,11 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-i18n = ["Babel (>=2.7)"]
-
 [package.dependencies]
 MarkupSafe = ">=2.0"
+
+[package.extras]
+i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jmespath"
@@ -871,17 +834,14 @@ category = "main"
 optional = false
 python-versions = "*"
 
+[package.dependencies]
+attrs = ">=17.4.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
+
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
 format_nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=1.11)"]
-
-[package.dependencies]
-attrs = ">=17.4.0"
-pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
-
-[package.dependencies.importlib-metadata]
-version = "*"
-python = "<3.8"
 
 [[package]]
 name = "lxml"
@@ -905,12 +865,12 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
+[package.dependencies]
+MarkupSafe = ">=0.9.2"
+
 [package.extras]
 babel = ["babel"]
 lingua = ["lingua"]
-
-[package.dependencies]
-MarkupSafe = ">=0.9.2"
 
 [[package]]
 name = "marko"
@@ -1028,14 +988,12 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
-
-[package.dependencies]
-[package.dependencies.importlib-metadata]
-version = ">=0.12"
-python = "<3.8"
 
 [[package]]
 name = "psycopg2-binary"
@@ -1077,11 +1035,11 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-toml = ["toml"]
-
 [package.dependencies]
 snowballstemmer = "*"
+
+[package.extras]
+toml = ["toml"]
 
 [[package]]
 name = "pyflakes"
@@ -1099,12 +1057,12 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+cryptography = ">=35.0"
+
 [package.extras]
 docs = ["sphinx", "sphinx-rtd-theme"]
 test = ["flaky", "pretend", "pytest (>=3.0.1)"]
-
-[package.dependencies]
-cryptography = ">=35.0"
 
 [[package]]
 name = "pyparsing"
@@ -1151,28 +1109,25 @@ test = ["nose"]
 
 [[package]]
 name = "pytest"
-version = "7.0.0"
+version = "7.0.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
-
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 tomli = ">=1.0.0"
 
-[package.dependencies.importlib-metadata]
-version = ">=0.12"
-python = "<3.8"
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1204,11 +1159,11 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-unidecode = ["Unidecode (>=1.1.1)"]
-
 [package.dependencies]
 text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pytz"
@@ -1234,17 +1189,14 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
-[package.extras]
-hiredis = ["hiredis (>=1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (20.0.1)", "requests (>=2.26.0)"]
-
 [package.dependencies]
 deprecated = ">=1.2.3"
+importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
 packaging = ">=20.4"
 
-[package.dependencies.importlib-metadata]
-version = ">=1.0"
-python = "<3.8"
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
 name = "requests"
@@ -1254,21 +1206,15 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
-[package.extras]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
-
 [package.dependencies]
 certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
 urllib3 = ">=1.21.1,<1.27"
 
-[package.dependencies.charset-normalizer]
-version = ">=2.0.0,<2.1.0"
-python = ">=3"
-
-[package.dependencies.idna]
-version = ">=2.5,<4"
-python = ">=3"
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "requests-oauthlib"
@@ -1278,12 +1224,12 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
-[package.extras]
-rsa = ["oauthlib (>=3.0.0)"]
-
 [package.dependencies]
 oauthlib = ">=3.0.0"
 requests = ">=2.0.0"
+
+[package.extras]
+rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rfc3986"
@@ -1304,11 +1250,11 @@ category = "main"
 optional = false
 python-versions = ">= 3.6"
 
-[package.extras]
-crt = ["botocore (>=1.20.29,<2.0a.0)"]
-
 [package.dependencies]
 botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "shellingham"
@@ -1358,6 +1304,10 @@ category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
+[package.dependencies]
+greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
 [package.extras]
 aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
 aiosqlite = ["greenlet (!=0.4.17)", "aiosqlite"]
@@ -1377,15 +1327,6 @@ postgresql_psycopg2binary = ["psycopg2-binary"]
 postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql (<1)", "pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
-
-[package.dependencies]
-[package.dependencies.greenlet]
-version = "!=0.4.17"
-python = ">=3"
-
-[package.dependencies.importlib-metadata]
-version = "*"
-python = "<3.8"
 
 [[package]]
 name = "stringcase"
@@ -1432,31 +1373,24 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
+shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
+
 [package.extras]
 all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
 doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)"]
-test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (0.910)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)"]
-
-[package.dependencies]
-click = ">=7.1.1,<9.0.0"
-
-[package.dependencies.colorama]
-version = ">=0.4.3,<0.5.0"
-optional = true
-
-[package.dependencies.shellingham]
-version = ">=1.3.0,<2.0.0"
-optional = true
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.0.1"
+version = "4.1.0"
 description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
 python-versions = ">=3.6"
-marker = "python_version < \"3.8\""
 
 [[package]]
 name = "urllib3"
@@ -1469,7 +1403,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "urlobject"
@@ -1487,12 +1421,12 @@ category = "main"
 optional = false
 python-versions = ">=3.4"
 
-[package.extras]
-test = ["pytest (>=2.2.3)", "flake8 (>=2.4.0)", "isort (>=4.2.2)"]
-
 [package.dependencies]
 decorator = ">=3.4.0"
 six = ">=1.4.0"
+
+[package.extras]
+test = ["pytest (>=2.2.3)", "flake8 (>=2.4.0)", "isort (>=4.2.2)"]
 
 [[package]]
 name = "waitress"
@@ -1542,14 +1476,14 @@ category = "dev"
 optional = false
 python-versions = ">=3.6, <4"
 
-[package.extras]
-docs = ["docutils", "pylons-sphinx-themes (>=1.0.8)", "Sphinx (>=1.8.1)"]
-tests = ["coverage", "pastedeploy", "pyquery", "pytest", "pytest-cov", "wsgiproxy2"]
-
 [package.dependencies]
 beautifulsoup4 = "*"
 waitress = ">=0.8.5"
 WebOb = ">=1.2"
+
+[package.extras]
+docs = ["docutils", "pylons-sphinx-themes (>=1.0.8)", "Sphinx (>=1.8.1)"]
+tests = ["coverage", "pastedeploy", "pyquery", "pytest", "pytest-cov", "wsgiproxy2"]
 
 [[package]]
 name = "werkzeug"
@@ -1559,13 +1493,11 @@ category = "main"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+dataclasses = {version = "*", markers = "python_version < \"3.7\""}
+
 [package.extras]
 watchdog = ["watchdog"]
-
-[package.dependencies]
-[package.dependencies.dataclasses]
-version = "*"
-python = "<3.7"
 
 [[package]]
 name = "whitenoise"
@@ -1594,13 +1526,13 @@ category = "main"
 optional = false
 python-versions = "*"
 
+[package.dependencies]
+MarkupSafe = "*"
+
 [package.extras]
 email = ["email-validator"]
 ipaddress = ["ipaddress"]
 locale = ["Babel (>=1.3)"]
-
-[package.dependencies]
-MarkupSafe = "*"
 
 [[package]]
 name = "zipp"
@@ -1609,13 +1541,13 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.6"
-marker = "python_version < \"3.9\""
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
+lock-version = "1.1"
 python-versions = ">=3.6,<4"
 content-hash = "28fac787660c244be30e4cac4d1cd0fe898c1280155a33e1173c9dd81b68ec13"
 
@@ -1725,8 +1657,8 @@ chardet = [
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
-    {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -1820,8 +1752,8 @@ cssselect = [
     {file = "cssselect-1.1.0.tar.gz", hash = "sha256:f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc"},
 ]
 dataclasses = [
-    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
-    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
+    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
@@ -2006,6 +1938,7 @@ greenlet = [
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
 gunicorn = [
+    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
     {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
 ]
 hiredis = [
@@ -2346,8 +2279,8 @@ pystache = [
     {file = "pystache-0.6.0.tar.gz", hash = "sha256:93bf92b2149a4c4b58d12142e2c4c6dd5c08d89e4c95afccd4b6efe2ee1d470d"},
 ]
 pytest = [
-    {file = "pytest-7.0.0-py3-none-any.whl", hash = "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9"},
-    {file = "pytest-7.0.0.tar.gz", hash = "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"},
+    {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
+    {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -2372,18 +2305,26 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -2480,8 +2421,8 @@ typer = [
     {file = "typer-0.4.0.tar.gz", hash = "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
-    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
+    {file = "typing_extensions-4.1.0-py3-none-any.whl", hash = "sha256:c13180fbaa7cd97065a4915ceba012bdb31dc34743e63ddee16360161d358414"},
+    {file = "typing_extensions-4.1.0.tar.gz", hash = "sha256:ba97c5143e5bb067b57793c726dd857b1671d4b02ced273ca0538e71ff009095"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -320,7 +320,7 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "12.3.3"
+version = "13.0.0"
 description = "Faker is a Python package that generates fake data for you."
 category = "dev"
 optional = false
@@ -845,7 +845,7 @@ format_nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "lxml"
-version = "4.7.1"
+version = "4.8.0"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 category = "main"
 optional = false
@@ -1153,11 +1153,11 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-slugify"
-version = "5.0.2"
-description = "A Python Slugify application that handles Unicode"
+version = "6.0.1"
+description = "A Python slugify application that also handles Unicode"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
 text-unidecode = ">=1.3"
@@ -1183,7 +1183,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "redis"
-version = "4.1.3"
+version = "4.1.4"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
@@ -1780,8 +1780,8 @@ factory-boy = [
     {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
 ]
 faker = [
-    {file = "Faker-12.3.3-py3-none-any.whl", hash = "sha256:a7244b7f25503811072122d98918f445df276ea80c5e38448f51a3b765665ece"},
-    {file = "Faker-12.3.3.tar.gz", hash = "sha256:dc46ddaf9bd33998c49c69dc68273bb5b11e41820b38f05296d3241c7d681597"},
+    {file = "Faker-13.0.0-py3-none-any.whl", hash = "sha256:ee8d9181137cdd2b198bd3d0653b0a3b7b385213862348e15ba8a423324b702b"},
+    {file = "Faker-13.0.0.tar.gz", hash = "sha256:f545b2a1ba5f7effc4ed71af0a5204d939445f0190838d41bee6bc160958bfbe"},
 ]
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
@@ -2028,66 +2028,67 @@ jsonschema = [
     {file = "jsonschema-4.0.0.tar.gz", hash = "sha256:bc51325b929171791c42ebc1c70b9713eb134d3bb8ebd5474c8b659b15be6d86"},
 ]
 lxml = [
-    {file = "lxml-4.7.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:d546431636edb1d6a608b348dd58cc9841b81f4116745857b6cb9f8dadb2725f"},
-    {file = "lxml-4.7.1-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6308062534323f0d3edb4e702a0e26a76ca9e0e23ff99be5d82750772df32a9e"},
-    {file = "lxml-4.7.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f76dbe44e31abf516114f6347a46fa4e7c2e8bceaa4b6f7ee3a0a03c8eba3c17"},
-    {file = "lxml-4.7.1-cp27-cp27m-win32.whl", hash = "sha256:d5618d49de6ba63fe4510bdada62d06a8acfca0b4b5c904956c777d28382b419"},
-    {file = "lxml-4.7.1-cp27-cp27m-win_amd64.whl", hash = "sha256:9393a05b126a7e187f3e38758255e0edf948a65b22c377414002d488221fdaa2"},
-    {file = "lxml-4.7.1-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:50d3dba341f1e583265c1a808e897b4159208d814ab07530202b6036a4d86da5"},
-    {file = "lxml-4.7.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:44f552e0da3c8ee3c28e2eb82b0b784200631687fc6a71277ea8ab0828780e7d"},
-    {file = "lxml-4.7.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e662c6266e3a275bdcb6bb049edc7cd77d0b0f7e119a53101d367c841afc66dc"},
-    {file = "lxml-4.7.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:4c093c571bc3da9ebcd484e001ba18b8452903cd428c0bc926d9b0141bcb710e"},
-    {file = "lxml-4.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3e26ad9bc48d610bf6cc76c506b9e5ad9360ed7a945d9be3b5b2c8535a0145e3"},
-    {file = "lxml-4.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a5f623aeaa24f71fce3177d7fee875371345eb9102b355b882243e33e04b7175"},
-    {file = "lxml-4.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7b5e2acefd33c259c4a2e157119c4373c8773cf6793e225006a1649672ab47a6"},
-    {file = "lxml-4.7.1-cp310-cp310-win32.whl", hash = "sha256:67fa5f028e8a01e1d7944a9fb616d1d0510d5d38b0c41708310bd1bc45ae89f6"},
-    {file = "lxml-4.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:b1d381f58fcc3e63fcc0ea4f0a38335163883267f77e4c6e22d7a30877218a0e"},
-    {file = "lxml-4.7.1-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:38d9759733aa04fb1697d717bfabbedb21398046bd07734be7cccc3d19ea8675"},
-    {file = "lxml-4.7.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dfd0d464f3d86a1460683cd742306d1138b4e99b79094f4e07e1ca85ee267fe7"},
-    {file = "lxml-4.7.1-cp35-cp35m-win32.whl", hash = "sha256:534e946bce61fd162af02bad7bfd2daec1521b71d27238869c23a672146c34a5"},
-    {file = "lxml-4.7.1-cp35-cp35m-win_amd64.whl", hash = "sha256:6ec829058785d028f467be70cd195cd0aaf1a763e4d09822584ede8c9eaa4b03"},
-    {file = "lxml-4.7.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:ade74f5e3a0fd17df5782896ddca7ddb998845a5f7cd4b0be771e1ffc3b9aa5b"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:41358bfd24425c1673f184d7c26c6ae91943fe51dfecc3603b5e08187b4bcc55"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6e56521538f19c4a6690f439fefed551f0b296bd785adc67c1777c348beb943d"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5b0f782f0e03555c55e37d93d7a57454efe7495dab33ba0ccd2dbe25fc50f05d"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:490712b91c65988012e866c411a40cc65b595929ececf75eeb4c79fcc3bc80a6"},
-    {file = "lxml-4.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:34c22eb8c819d59cec4444d9eebe2e38b95d3dcdafe08965853f8799fd71161d"},
-    {file = "lxml-4.7.1-cp36-cp36m-win32.whl", hash = "sha256:2a906c3890da6a63224d551c2967413b8790a6357a80bf6b257c9a7978c2c42d"},
-    {file = "lxml-4.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:36b16fecb10246e599f178dd74f313cbdc9f41c56e77d52100d1361eed24f51a"},
-    {file = "lxml-4.7.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:a5edc58d631170de90e50adc2cc0248083541affef82f8cd93bea458e4d96db8"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:87c1b0496e8c87ec9db5383e30042357b4839b46c2d556abd49ec770ce2ad868"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:0a5f0e4747f31cff87d1eb32a6000bde1e603107f632ef4666be0dc065889c7a"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:bf6005708fc2e2c89a083f258b97709559a95f9a7a03e59f805dd23c93bc3986"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc15874816b9320581133ddc2096b644582ab870cf6a6ed63684433e7af4b0d3"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0b5e96e25e70917b28a5391c2ed3ffc6156513d3db0e1476c5253fcd50f7a944"},
-    {file = "lxml-4.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ec9027d0beb785a35aa9951d14e06d48cfbf876d8ff67519403a2522b181943b"},
-    {file = "lxml-4.7.1-cp37-cp37m-win32.whl", hash = "sha256:9fbc0dee7ff5f15c4428775e6fa3ed20003140560ffa22b88326669d53b3c0f4"},
-    {file = "lxml-4.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:1104a8d47967a414a436007c52f533e933e5d52574cab407b1e49a4e9b5ddbd1"},
-    {file = "lxml-4.7.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fc9fb11b65e7bc49f7f75aaba1b700f7181d95d4e151cf2f24d51bfd14410b77"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:317bd63870b4d875af3c1be1b19202de34c32623609ec803b81c99193a788c1e"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:610807cea990fd545b1559466971649e69302c8a9472cefe1d6d48a1dee97440"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:09b738360af8cb2da275998a8bf79517a71225b0de41ab47339c2beebfff025f"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6a2ab9d089324d77bb81745b01f4aeffe4094306d939e92ba5e71e9a6b99b71e"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:eed394099a7792834f0cb4a8f615319152b9d801444c1c9e1b1a2c36d2239f9e"},
-    {file = "lxml-4.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:735e3b4ce9c0616e85f302f109bdc6e425ba1670a73f962c9f6b98a6d51b77c9"},
-    {file = "lxml-4.7.1-cp38-cp38-win32.whl", hash = "sha256:772057fba283c095db8c8ecde4634717a35c47061d24f889468dc67190327bcd"},
-    {file = "lxml-4.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:13dbb5c7e8f3b6a2cf6e10b0948cacb2f4c9eb05029fe31c60592d08ac63180d"},
-    {file = "lxml-4.7.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:718d7208b9c2d86aaf0294d9381a6acb0158b5ff0f3515902751404e318e02c9"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:5bee1b0cbfdb87686a7fb0e46f1d8bd34d52d6932c0723a86de1cc532b1aa489"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:e410cf3a2272d0a85526d700782a2fa92c1e304fdcc519ba74ac80b8297adf36"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:585ea241ee4961dc18a95e2f5581dbc26285fcf330e007459688096f76be8c42"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a555e06566c6dc167fbcd0ad507ff05fd9328502aefc963cb0a0547cfe7f00db"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:adaab25be351fff0d8a691c4f09153647804d09a87a4e4ea2c3f9fe9e8651851"},
-    {file = "lxml-4.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:82d16a64236970cb93c8d63ad18c5b9f138a704331e4b916b2737ddfad14e0c4"},
-    {file = "lxml-4.7.1-cp39-cp39-win32.whl", hash = "sha256:59e7da839a1238807226f7143c68a479dee09244d1b3cf8c134f2fce777d12d0"},
-    {file = "lxml-4.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:a1bbc4efa99ed1310b5009ce7f3a1784698082ed2c1ef3895332f5df9b3b92c2"},
-    {file = "lxml-4.7.1-pp37-pypy37_pp73-macosx_10_14_x86_64.whl", hash = "sha256:0607ff0988ad7e173e5ddf7bf55ee65534bd18a5461183c33e8e41a59e89edf4"},
-    {file = "lxml-4.7.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:6c198bfc169419c09b85ab10cb0f572744e686f40d1e7f4ed09061284fc1303f"},
-    {file = "lxml-4.7.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a58d78653ae422df6837dd4ca0036610b8cb4962b5cfdbd337b7b24de9e5f98a"},
-    {file = "lxml-4.7.1-pp38-pypy38_pp73-macosx_10_14_x86_64.whl", hash = "sha256:e18281a7d80d76b66a9f9e68a98cf7e1d153182772400d9a9ce855264d7d0ce7"},
-    {file = "lxml-4.7.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:8e54945dd2eeb50925500957c7c579df3cd07c29db7810b83cf30495d79af267"},
-    {file = "lxml-4.7.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:447d5009d6b5447b2f237395d0018901dcc673f7d9f82ba26c1b9f9c3b444b60"},
-    {file = "lxml-4.7.1.tar.gz", hash = "sha256:a1613838aa6b89af4ba10a0f3a972836128801ed008078f8c1244e65958f1b24"},
+    {file = "lxml-4.8.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e1ab2fac607842ac36864e358c42feb0960ae62c34aa4caaf12ada0a1fb5d99b"},
+    {file = "lxml-4.8.0-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28d1af847786f68bec57961f31221125c29d6f52d9187c01cd34dc14e2b29430"},
+    {file = "lxml-4.8.0-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b92d40121dcbd74831b690a75533da703750f7041b4bf951befc657c37e5695a"},
+    {file = "lxml-4.8.0-cp27-cp27m-win32.whl", hash = "sha256:e01f9531ba5420838c801c21c1b0f45dbc9607cb22ea2cf132844453bec863a5"},
+    {file = "lxml-4.8.0-cp27-cp27m-win_amd64.whl", hash = "sha256:6259b511b0f2527e6d55ad87acc1c07b3cbffc3d5e050d7e7bcfa151b8202df9"},
+    {file = "lxml-4.8.0-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1010042bfcac2b2dc6098260a2ed022968dbdfaf285fc65a3acf8e4eb1ffd1bc"},
+    {file = "lxml-4.8.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fa56bb08b3dd8eac3a8c5b7d075c94e74f755fd9d8a04543ae8d37b1612dd170"},
+    {file = "lxml-4.8.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:31ba2cbc64516dcdd6c24418daa7abff989ddf3ba6d3ea6f6ce6f2ed6e754ec9"},
+    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:31499847fc5f73ee17dbe1b8e24c6dafc4e8d5b48803d17d22988976b0171f03"},
+    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5f7d7d9afc7b293147e2d506a4596641d60181a35279ef3aa5778d0d9d9123fe"},
+    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a3c5f1a719aa11866ffc530d54ad965063a8cbbecae6515acbd5f0fae8f48eaa"},
+    {file = "lxml-4.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6268e27873a3d191849204d00d03f65c0e343b3bcb518a6eaae05677c95621d1"},
+    {file = "lxml-4.8.0-cp310-cp310-win32.whl", hash = "sha256:330bff92c26d4aee79c5bc4d9967858bdbe73fdbdbacb5daf623a03a914fe05b"},
+    {file = "lxml-4.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:b2582b238e1658c4061ebe1b4df53c435190d22457642377fd0cb30685cdfb76"},
+    {file = "lxml-4.8.0-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a2bfc7e2a0601b475477c954bf167dee6d0f55cb167e3f3e7cefad906e7759f6"},
+    {file = "lxml-4.8.0-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a1547ff4b8a833511eeaceacbcd17b043214fcdb385148f9c1bc5556ca9623e2"},
+    {file = "lxml-4.8.0-cp35-cp35m-win32.whl", hash = "sha256:a9f1c3489736ff8e1c7652e9dc39f80cff820f23624f23d9eab6e122ac99b150"},
+    {file = "lxml-4.8.0-cp35-cp35m-win_amd64.whl", hash = "sha256:530f278849031b0eb12f46cca0e5db01cfe5177ab13bd6878c6e739319bae654"},
+    {file = "lxml-4.8.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:078306d19a33920004addeb5f4630781aaeabb6a8d01398045fcde085091a169"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:86545e351e879d0b72b620db6a3b96346921fa87b3d366d6c074e5a9a0b8dadb"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24f5c5ae618395ed871b3d8ebfcbb36e3f1091fd847bf54c4de623f9107942f3"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:bbab6faf6568484707acc052f4dfc3802bdb0cafe079383fbaa23f1cdae9ecd4"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7993232bd4044392c47779a3c7e8889fea6883be46281d45a81451acfd704d7e"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d6483b1229470e1d8835e52e0ff3c6973b9b97b24cd1c116dca90b57a2cc613"},
+    {file = "lxml-4.8.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ad4332a532e2d5acb231a2e5d33f943750091ee435daffca3fec0a53224e7e33"},
+    {file = "lxml-4.8.0-cp36-cp36m-win32.whl", hash = "sha256:db3535733f59e5605a88a706824dfcb9bd06725e709ecb017e165fc1d6e7d429"},
+    {file = "lxml-4.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5f148b0c6133fb928503cfcdfdba395010f997aa44bcf6474fcdd0c5398d9b63"},
+    {file = "lxml-4.8.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:8a31f24e2a0b6317f33aafbb2f0895c0bce772980ae60c2c640d82caac49628a"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:719544565c2937c21a6f76d520e6e52b726d132815adb3447ccffbe9f44203c4"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:c0b88ed1ae66777a798dc54f627e32d3b81c8009967c63993c450ee4cbcbec15"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fa9b7c450be85bfc6cd39f6df8c5b8cbd76b5d6fc1f69efec80203f9894b885f"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e9f84ed9f4d50b74fbc77298ee5c870f67cb7e91dcdc1a6915cb1ff6a317476c"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1d650812b52d98679ed6c6b3b55cbb8fe5a5460a0aef29aeb08dc0b44577df85"},
+    {file = "lxml-4.8.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:80bbaddf2baab7e6de4bc47405e34948e694a9efe0861c61cdc23aa774fcb141"},
+    {file = "lxml-4.8.0-cp37-cp37m-win32.whl", hash = "sha256:6f7b82934c08e28a2d537d870293236b1000d94d0b4583825ab9649aef7ddf63"},
+    {file = "lxml-4.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e1fd7d2fe11f1cb63d3336d147c852f6d07de0d0020d704c6031b46a30b02ca8"},
+    {file = "lxml-4.8.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5045ee1ccd45a89c4daec1160217d363fcd23811e26734688007c26f28c9e9e7"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0c1978ff1fd81ed9dcbba4f91cf09faf1f8082c9d72eb122e92294716c605428"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cbf2ff155b19dc4d4100f7442f6a697938bf4493f8d3b0c51d45568d5666b5"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ce13d6291a5f47c1c8dbd375baa78551053bc6b5e5c0e9bb8e39c0a8359fd52f"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e11527dc23d5ef44d76fef11213215c34f36af1608074561fcc561d983aeb870"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:60d2f60bd5a2a979df28ab309352cdcf8181bda0cca4529769a945f09aba06f9"},
+    {file = "lxml-4.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:62f93eac69ec0f4be98d1b96f4d6b964855b8255c345c17ff12c20b93f247b68"},
+    {file = "lxml-4.8.0-cp38-cp38-win32.whl", hash = "sha256:20b8a746a026017acf07da39fdb10aa80ad9877046c9182442bf80c84a1c4696"},
+    {file = "lxml-4.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:891dc8f522d7059ff0024cd3ae79fd224752676447f9c678f2a5c14b84d9a939"},
+    {file = "lxml-4.8.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b6fc2e2fb6f532cf48b5fed57567ef286addcef38c28874458a41b7837a57807"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:74eb65ec61e3c7c019d7169387d1b6ffcfea1b9ec5894d116a9a903636e4a0b1"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:627e79894770783c129cc5e89b947e52aa26e8e0557c7e205368a809da4b7939"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:545bd39c9481f2e3f2727c78c169425efbfb3fbba6e7db4f46a80ebb249819ca"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5a58d0b12f5053e270510bf12f753a76aaf3d74c453c00942ed7d2c804ca845c"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ec4b4e75fc68da9dc0ed73dcdb431c25c57775383fec325d23a770a64e7ebc87"},
+    {file = "lxml-4.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5804e04feb4e61babf3911c2a974a5b86f66ee227cc5006230b00ac6d285b3a9"},
+    {file = "lxml-4.8.0-cp39-cp39-win32.whl", hash = "sha256:aa0cf4922da7a3c905d000b35065df6184c0dc1d866dd3b86fd961905bbad2ea"},
+    {file = "lxml-4.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:dd10383f1d6b7edf247d0960a3db274c07e96cf3a3fc7c41c8448f93eac3fb1c"},
+    {file = "lxml-4.8.0-pp37-pypy37_pp73-macosx_10_14_x86_64.whl", hash = "sha256:2403a6d6fb61c285969b71f4a3527873fe93fd0abe0832d858a17fe68c8fa507"},
+    {file = "lxml-4.8.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:986b7a96228c9b4942ec420eff37556c5777bfba6758edcb95421e4a614b57f9"},
+    {file = "lxml-4.8.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6fe4ef4402df0250b75ba876c3795510d782def5c1e63890bde02d622570d39e"},
+    {file = "lxml-4.8.0-pp38-pypy38_pp73-macosx_10_14_x86_64.whl", hash = "sha256:f10ce66fcdeb3543df51d423ede7e238be98412232fca5daec3e54bcd16b8da0"},
+    {file = "lxml-4.8.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:730766072fd5dcb219dd2b95c4c49752a54f00157f322bc6d71f7d2a31fecd79"},
+    {file = "lxml-4.8.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8b99ec73073b37f9ebe8caf399001848fced9c08064effdbfc4da2b5a8d07b93"},
+    {file = "lxml-4.8.0.tar.gz", hash = "sha256:f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23"},
 ]
 mako = [
     {file = "Mako-1.1.6-py2.py3-none-any.whl", hash = "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"},
@@ -2291,8 +2292,8 @@ python-dotenv = [
     {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
 ]
 python-slugify = [
-    {file = "python-slugify-5.0.2.tar.gz", hash = "sha256:f13383a0b9fcbe649a1892b9c8eb4f8eab1d6d84b84bb7a624317afa98159cab"},
-    {file = "python_slugify-5.0.2-py2.py3-none-any.whl", hash = "sha256:6d8c5df75cd4a7c3a2d21e257633de53f52ab0265cd2d1dc62a730e8194a7380"},
+    {file = "python-slugify-6.0.1.tar.gz", hash = "sha256:ba72aa9d9f0514c0c3dd4430442f698ccc27a24d19630473663a71e3ec606bc1"},
+    {file = "python_slugify-6.0.1-py2.py3-none-any.whl", hash = "sha256:89eec682c5180ba64811c9906a28184bbcc0a35792ba1bda3b5c2ab0cb2d0f67"},
 ]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
@@ -2330,8 +2331,8 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 redis = [
-    {file = "redis-4.1.3-py3-none-any.whl", hash = "sha256:267e89e476eb684517584e8988f1e5d755f483a368c133020c4c40e8b676bc5d"},
-    {file = "redis-4.1.3.tar.gz", hash = "sha256:f2715caad9f0e8c6ff8df46d3c4c9022a3929001f530f66b62747554d3067068"},
+    {file = "redis-4.1.4-py3-none-any.whl", hash = "sha256:04629f8e42be942c4f7d1812f2094568f04c612865ad19ad3ace3005da70631a"},
+    {file = "redis-4.1.4.tar.gz", hash = "sha256:1d9a0cdf89fdd93f84261733e24f55a7bbd413a9b219fdaf56e3e728ca9a2306"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -8,7 +8,7 @@ botocore==1.22.12
 certifi==2021.10.8
 cffi==1.15.0
 chardet==4.0.0
-charset-normalizer==2.0.11; python_version >= "3"
+charset-normalizer==2.0.12; python_version >= "3"
 click==8.0.3
 colorama==0.4.4
 cssmin==0.2.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,7 @@ decorator==5.1.1
 dnspython==1.16.0
 email-validator==1.1.3
 eventlet==0.30.2
-flask==2.0.2
+flask==2.0.3
 flask-assets==2.0
 flask-bcrypt==0.7.1
 flask-caching==1.10.1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 """Test configs."""
+
 from dribdat.app import init_app
 from dribdat.settings import DevConfig, ProdConfig
 from dribdat.utils import strtobool
+
 
 def test_production_config():
     """Production config."""
@@ -23,5 +25,5 @@ def test_dev_config():
 
 def test_truthy_config():
     """ Test conversion of truthy variables. """
-    assert strtobool(' tRuE') == True
-    assert strtobool('0') == False
+    assert strtobool(' tRuE') is True
+    assert strtobool('0') is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Model unit tests."""
+
 import datetime as dt
 
 import pytest
@@ -64,6 +65,7 @@ class TestUser:
         user.save()
         assert role in user.roles
 
+
 @pytest.mark.usefixtures('db')
 class TestEvent:
     """Event tests."""
@@ -112,7 +114,8 @@ class TestEvent:
         assert event.name == "test"
         assert event.countdown is not None
         assert event.countdown == tz_event
-        assert timesince(event.countdown, until=True) == "%d hours to go" % timediff_hours
+        assert timesince(
+            event.countdown, until=True) == "%d hours to go" % timediff_hours
 
 
 # @pytest.mark.usefixtures('db')


### PR DESCRIPTION
- The default [progress stages](https://meta.dribdat.cc/event/1/stages) elaborate a path in data, inspired by the [School of Data](https://schoolofdata.org/methodology/) pipeline.
- Countdown clock replaced with the more robust [Flipdown](https://www.npmjs.com/package/flipdown) #253 (screenshot 1)
- A number representing the follower count is shown next to every project in Challenge stage (screenshot 2)
- Events are no longer automatically featured, just displayed as 'upcoming'.
- Icons added to the event header, where the host is more prominently shown (screenshot 2)
- Hexagrid issues have been addressed for odd row counts and various resolutions.
- The event information area under the hexagrid is more clearly visually contained.
- The new event checklist screen no longer requires login. You are asked in the next step.
- Challenge switcher fades out, instead of hiding, the challenges.
- Flask framework upgrade ([2.0.3](https://github.com/pallets/flask/releases/tag/2.0.3)).
- Library updates.


## Screenshots

![Screenshot from 2022-02-17 00-17-34](https://user-images.githubusercontent.com/31819/154373737-22db5ab3-4d86-4621-8363-85716cd11261.jpg)
_(1) Before and after view of the countdown clock._

![Screenshot from 2022-02-17 00-20-14](https://user-images.githubusercontent.com/31819/154374163-ca9cc63f-a2ae-4e37-94de-394e70dd83e6.png)
_(2) Event page improvements._