### PR TITLE
Project stats and team view

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -35,18 +35,21 @@ def socialize(kind):
 
 @click.command()
 @click.argument('event', required=True)
-def numerise(event: int):
-    """Assign numbers to challenges."""
+@click.argument('clear', required=False, default=False)
+def numerise(event: int, clear: bool):
+    """Assign numbers to challenge hashtags for an EVENT ID."""
     # TODO: use a parameter for alphabetic, id-based, etc.
     # Generate some primes, thanks @DhanushNayak
     primes = list(filter(lambda x: not list(filter(lambda y : x%y==0, range(2,x))),range(2,200)))
     with create_app().app_context():
         from dribdat.user.models import Event
-        challenges = Event.query.filter_by(id=event).first_or_404().projects
+        challenges = Event.query.filter_by(id=event) \
+                     .first_or_404().projects
         ix = 0
         for c in challenges:
+            if c.is_hidden: continue
             ch = "" # push existing hashtag aside
-            if len(c.hashtag) > 0:
+            if not clear and len(c.hashtag) > 0:
                 ch = " " + ch
             c.hashtag = str(primes[ix]) + ch
             c.save()

--- a/cli.py
+++ b/cli.py
@@ -34,6 +34,27 @@ def socialize(kind):
 
 
 @click.command()
+@click.argument('event', required=True)
+def numerise(event: int):
+    """Assign numbers to challenges."""
+    # TODO: use a parameter for alphabetic, id-based, etc.
+    # Generate some primes, thanks @DhanushNayak
+    primes = list(filter(lambda x: not list(filter(lambda y : x%y==0, range(2,x))),range(2,200)))
+    with create_app().app_context():
+        from dribdat.user.models import Event
+        challenges = Event.query.filter_by(id=event).first_or_404().projects
+        ix = 0
+        for c in challenges:
+            ch = "" # push existing hashtag aside
+            if len(c.hashtag) > 0:
+                ch = " " + ch
+            c.hashtag = str(primes[ix]) + ch
+            c.save()
+            ix = ix + 1
+        print("Enumerated %d challenges." % len(challenges))
+
+
+@click.command()
 @click.argument('name', required=True)
 @click.argument('start', required=False)
 @click.argument('finish', required=False)
@@ -104,6 +125,7 @@ def cli():
 
 
 cli.add_command(socialize)
+cli.add_command(numerise)
 cli.add_command(imports)
 cli.add_command(exports)
 

--- a/cli.py
+++ b/cli.py
@@ -43,10 +43,10 @@ def numerise(event: int, clear: bool):
     primes = list(filter(lambda x: not list(filter(lambda y : x%y==0, range(2,x))),range(2,200)))
     with create_app().app_context():
         from dribdat.user.models import Event
-        challenges = Event.query.filter_by(id=event) \
-                     .first_or_404().projects
+        projects = Event.query.filter_by(id=event) \
+                   .first_or_404().projects
         ix = 0
-        for c in challenges:
+        for c in projects:
             if c.is_hidden: continue
             ch = "" # push existing hashtag aside
             if not clear and len(c.hashtag) > 0:
@@ -54,7 +54,7 @@ def numerise(event: int, clear: bool):
             c.hashtag = str(primes[ix]) + ch
             c.save()
             ix = ix + 1
-        print("Enumerated %d challenges." % len(challenges))
+        print("Enumerated %d projects." % len(projects))
 
 
 @click.command()

--- a/cli.py
+++ b/cli.py
@@ -36,11 +36,16 @@ def socialize(kind):
 @click.command()
 @click.argument('event', required=True)
 @click.argument('clear', required=False, default=False)
-def numerise(event: int, clear: bool):
+@click.argument('primes', required=False, default=True)
+@click.argument('challenges', required=False, default=True)
+def numerise(event: int, clear: bool, primes: bool, challenges: bool):
     """Assign numbers to challenge hashtags for an EVENT ID."""
-    # TODO: use a parameter for alphabetic, id-based, etc.
-    # Generate some primes, thanks @DhanushNayak
-    primes = list(filter(lambda x: not list(filter(lambda y : x%y==0, range(2,x))),range(2,200)))
+    # TODO: use a parameter for sort order alphabetic, id-based, etc.
+    if primes:
+        # Generate some primes, thanks @DhanushNayak
+        nq = list(filter(lambda x: not list(filter(lambda y : x%y==0, range(2,x))),range(2,200)))
+    else:
+        nq = list(range(1,200))
     with create_app().app_context():
         from dribdat.user.models import Event
         projects = Event.query.filter_by(id=event) \
@@ -48,10 +53,12 @@ def numerise(event: int, clear: bool):
         ix = 0
         for c in projects:
             if c.is_hidden: continue
+            if challenges and not c.is_challenge: continue
+            if not challenges and c.is_challenge: continue
             ch = "" # push existing hashtag aside
             if not clear and len(c.hashtag) > 0:
                 ch = " " + ch
-            c.hashtag = str(primes[ix]) + ch
+            c.hashtag = str(nq[ix]) + ch
             c.save()
             ix = ix + 1
         print("Enumerated %d projects." % len(projects))

--- a/dribdat/admin/forms.py
+++ b/dribdat/admin/forms.py
@@ -176,7 +176,7 @@ class ProjectForm(FlaskForm):
     source_url = URLField(u'Source link', [length(max=2048)])
     download_url = URLField(u'Download link', [length(max=2048)])
     image_url = URLField(u'Image link', [length(max=255)])
-    logo_color = StringField(u'Custom color', [length(max=7)])
+    logo_color = StringField(u'Custom color')
     logo_icon = StringField(u'Custom icon', [length(max=20)])
     submit = SubmitField(u'Save')
 
@@ -188,7 +188,7 @@ class CategoryForm(FlaskForm):
     name = StringField(u'Name', [length(max=80), DataRequired()])
     description = TextAreaField(u'Description',
                                 description=u'Markdown and HTML supported')
-    logo_color = StringField(u'Custom color', [length(max=7)])
+    logo_color = StringField(u'Custom color')
     logo_icon = StringField(u'Custom icon', [length(max=20)],
                             description=u'fontawesome.com/v4/cheatsheet')
     event_id = SelectField(u'Specific to an event, or global if blank',

--- a/dribdat/admin/views.py
+++ b/dribdat/admin/views.py
@@ -91,15 +91,19 @@ def users(page=1):
             User.username.asc()
         )
     else:  # Default: updated
+        sort_by = 'updated'
         users = User.query.order_by(
             User.updated_at.desc()
         )
     search_by = request.args.get('search')
     if search_by and len(search_by) > 1:
         q = "%%%s%%" % search_by.lower()
-        users = users.filter(User.username.ilike(q))
+        if '@' in search_by:
+            users = users.filter(User.email.ilike(q))
+        else:
+            users = users.filter(User.username.ilike(q))
     users = users.paginate(page, per_page=20)
-    return render_template('admin/users.html',
+    return render_template('admin/users.html', sort_by=sort_by,
                            data=users, endpoint='admin.users', active='users')
 
 

--- a/dribdat/admin/views.py
+++ b/dribdat/admin/views.py
@@ -76,11 +76,11 @@ def users(page=1):
         )
     elif sort_by == 'sso':
         users = User.query.order_by(
-            User.sso_id.asc()
+            User.sso_id.desc()
         )
-    elif sort_by == 'created':
+    elif sort_by == 'updated':
         users = User.query.order_by(
-            User.created_at.desc()
+            User.updated_at.desc()
         )
     elif sort_by == 'email':
         users = User.query.order_by(
@@ -90,10 +90,10 @@ def users(page=1):
         users = User.query.order_by(
             User.username.asc()
         )
-    else:  # Default: updated
-        sort_by = 'updated'
+    else:  # Default: created
+        sort_by = 'created'
         users = User.query.order_by(
-            User.updated_at.desc()
+            User.created_at.desc()
         )
     search_by = request.args.get('search')
     if search_by and len(search_by) > 1:

--- a/dribdat/aggregation.py
+++ b/dribdat/aggregation.py
@@ -14,6 +14,7 @@ from dribdat.apifetch import (
 )
 import json
 import re
+from sqlalchemy import and_
 
 
 def GetProjectData(url):
@@ -183,11 +184,15 @@ def GetEventUsers(event):
         return None
     users = []
     userlist = []
-    for p in event.projects:
-        for u in p.get_team():
-            if u.id not in userlist:
-                userlist.append(u.id)
-                users.append(u)
+    projects = set([p.id for p in event.projects])
+    activities = Activity.query.filter(and_(
+            Activity.name=='star', 
+            Activity.project_id.in_(projects)
+        )).all()
+    for a in activities:
+        if a.user_id not in userlist:
+            userlist.append(a.user_id)
+            users.append(a.user)
     return sorted(users, key=lambda x: x.username)
 
 

--- a/dribdat/aggregation.py
+++ b/dribdat/aggregation.py
@@ -58,6 +58,8 @@ def get_github_project(url):
         apiurl = apiurl[:-4]
     if apiurl == url:
         return {}
+    if apiurl.endswith('.md'):
+        return FetchWebProject(url)
     return FetchGithubProject(apiurl)
 
 

--- a/dribdat/aggregation.py
+++ b/dribdat/aggregation.py
@@ -190,7 +190,7 @@ def GetEventUsers(event):
             Activity.project_id.in_(projects)
         )).all()
     for a in activities:
-        if a.user_id not in userlist:
+        if a.user and a.user_id not in userlist:
             userlist.append(a.user_id)
             users.append(a.user)
     return sorted(users, key=lambda x: x.username)

--- a/dribdat/apifetch.py
+++ b/dribdat/apifetch.py
@@ -425,8 +425,8 @@ def FetchWebGitHub(url):
     if not url.endswith('.md') or not '/blob/' in url:
         return {}
     filename = url.split('/')[-1].replace('.md', '')
-    rawurl = url.replace('/blob/', '/raw/')
-    rawdata = requests.get(rawurl, timeout=REQUEST_TIMEOUT)
+    rawurl = url.replace('/blob/', '/raw/').replace("https://github.com/", '')
+    rawdata = requests.get("https://github.com/" + rawurl, timeout=REQUEST_TIMEOUT)
     text_content = rawdata.text or ""
     return {
         'type': 'Markdown',

--- a/dribdat/apifetch.py
+++ b/dribdat/apifetch.py
@@ -297,6 +297,12 @@ def FetchWebProject(project_url):
     # Google Document
     if project_url.startswith('https://docs.google.com/document'):
         return FetchWebGoogleDoc(data.text, project_url)
+    # Instructables
+    elif project_url.startswith('https://www.instructables.com/'):
+        return FetchWebInstructables(data.text, project_url)
+    # GitHub Markdown
+    elif project_url.startswith('https://github.com/'):
+        return FetchWebGitHub(project_url)
     # CodiMD / HackMD
     elif data.text.find('<div id="doc" ') > 0:
         return FetchWebCodiMD(data.text, project_url)
@@ -306,9 +312,6 @@ def FetchWebProject(project_url):
     # Etherpad
     elif data.text.find('pad.importExport.exportetherpad') > 0:
         return FetchWebEtherpad(data.text, project_url)
-    # Instructables
-    elif project_url.startswith('https://www.instructables.com/'):
-        return FetchWebInstructables(data.text, project_url)
 
 
 def FetchWebGoogleDoc(text, url):
@@ -415,6 +418,23 @@ def FetchWebInstructables(text, url):
     obj['source_url'] = url
     obj['logo_icon'] = 'wrench'
     return obj
+
+
+def FetchWebGitHub(url):
+    """Grab a Markdown source from a GitHub link."""
+    if not url.endswith('.md') or not '/blob/' in url:
+        return {}
+    filename = url.split('/')[-1].replace('.md', '')
+    rawurl = url.replace('/blob/', '/raw/')
+    rawdata = requests.get(rawurl, timeout=REQUEST_TIMEOUT)
+    text_content = rawdata.text or ""
+    return {
+        'type': 'Markdown',
+        'name': filename,
+        'description': text_content,
+        'source_url': url,
+        'logo_icon': 'outdent',
+    }
 
 
 def ParseInstructablesPage(content):

--- a/dribdat/apipackage.py
+++ b/dribdat/apipackage.py
@@ -26,7 +26,7 @@ def event_to_data_package(event, author=None, host_url='', full_content=False):
     """Create a Data Package from the data of an event."""
     # Define the author, if available
     contributors = []
-    if author and not author.is_anonymous:
+    if author and not author.is_anonymous and author.is_admin:
         contributors.append({
             "title": author.username,
             "path": author.webpage_url or '',
@@ -77,7 +77,7 @@ def event_to_data_package(event, author=None, host_url='', full_content=False):
                 name='activities',
                 data=get_event_activities(event.id, 500),
             ))
-        # print("Generating in-memory JSON of activities")
+        # print("Generating in-memory JSON of categories")
         package.add_resource(Resource(
                 name='categories',
                 data=get_event_categories(event.id),

--- a/dribdat/app.py
+++ b/dribdat/app.py
@@ -173,10 +173,12 @@ def register_filters(app):
 
     @app.template_filter()
     def format_date(value, format='%d.%m.%Y'):
+        if value is None: return ''
         return value.strftime(format)
 
     @app.template_filter()
     def format_datetime(value, format='%d.%m.%Y %H:%M'):
+        if value is None: return ''
         return value.strftime(format)
 
 

--- a/dribdat/mailer.py
+++ b/dribdat/mailer.py
@@ -5,12 +5,7 @@ from flask_mailman import EmailMessage
 from dribdat.utils import random_password  # noqa: I005
 
 
-async def send_async_email(app, msg):
-    with app.app_context():
-        msg.send()
-
-
-def user_activation(app, user):
+async def user_activation(app, user):
     """Send an activation by e-mail."""
     act_hash = random_password(32)
     with app.app_context():
@@ -29,4 +24,6 @@ def user_activation(app, user):
             + "Tap here to activate your account:\n\n%s" % act_url
         msg.to = [user.email]
         app.logger.info('Sending mail to user %d' % user.id)
-        send_async_email(app, msg)
+        await msg.send()
+        return True
+

--- a/dribdat/public/api.py
+++ b/dribdat/public/api.py
@@ -13,7 +13,7 @@ from flask import (
 from flask_login import login_required, current_user
 from sqlalchemy import or_
 
-from ..extensions import db
+from ..extensions import db, cache
 from ..utils import timesince, random_password
 from ..decorators import admin_required
 from ..user.models import Event, Project, Activity
@@ -495,8 +495,8 @@ def generate_event_package(event, format='json'):
         package.to_zip(fp_package.name)
         return send_file(fp_package.name, as_attachment=True)
 
-
 @blueprint.route('/event/current/datapackage.<format>', methods=["GET"])
+@cache.cached()
 def package_current_event(format):
     """Download a Data Package for an event."""
     event = Event.query.filter_by(is_current=True).first() or \
@@ -505,6 +505,7 @@ def package_current_event(format):
 
 
 @blueprint.route('/event/<int:event_id>/datapackage.<format>', methods=["GET"])
+@cache.cached()
 def package_specific_event(event_id, format):
     """Download a Data Package for an event."""
     event = Event.query.filter_by(id=event_id).first_or_404()

--- a/dribdat/public/auth.py
+++ b/dribdat/public/auth.py
@@ -70,7 +70,7 @@ def login():
 
 
 @blueprint.route("/register/", methods=['GET', 'POST'])
-def register():
+async def register():
     """Register new user."""
     if current_app.config['DRIBDAT_NOT_REGISTER']:
         flash("Registration currently not possible.", 'warning')
@@ -106,7 +106,7 @@ def register():
         new_user.active = False
         new_user.save()
         if current_app.config['MAIL_SERVER']:
-            user_activation(current_app, new_user)
+            await user_activation(current_app, new_user)
             flash("New accounts require activation. "
                   + "Please click the dribdat link in your e-mail.", 'success')
         else:

--- a/dribdat/public/auth.py
+++ b/dribdat/public/auth.py
@@ -422,14 +422,14 @@ def mattermost_login():
         flash('Unable to access Mattermost data', 'danger')
         return redirect(url_for("auth.login", local=1))
     resp_data = resp.json()
-    # print(resp_data)
     username = None
     if 'nickname' in resp_data:
         username = resp_data['nickname']
     elif 'username' in resp_data:
         username = resp_data['username']
-    if username is None:
+    if username is None or not 'email' in resp_data or not 'id' in resp_data:
         flash('Invalid Mattermost data format', 'danger')
+        # print(resp_data)
         return redirect(url_for("auth.login", local=1))
     return get_or_create_sso_user(
         resp_data['id'],
@@ -450,7 +450,7 @@ def hitobito_login():
         flash('Unable to access hitobito data', 'danger')
         return redirect(url_for("auth.login", local=1))
     resp_data = resp.json()
-    #print(resp_data)
+    # print(resp_data)
     username = None
     if 'nickname' in resp_data and resp_data['nickname'] is not None:
         username = resp_data['nickname']

--- a/dribdat/public/forms.py
+++ b/dribdat/public/forms.py
@@ -99,7 +99,7 @@ class ProjectDetailForm(FlaskForm):
         u'Cover image', [length(max=255)],
         description="URL of an image to display at the top of the page.")
     logo_color = StringField(
-        u'Color scheme', [length(max=7)],
+        u'Color scheme',
         description="Customize the color of your project page.")
     logo_icon = StringField(
         u'Named icon',

--- a/dribdat/public/views.py
+++ b/dribdat/public/views.py
@@ -256,8 +256,8 @@ def event_print(event_id):
     now = datetime.utcnow().strftime("%d.%m.%Y %H:%M")
     event = Event.query.filter_by(id=event_id).first_or_404()
     eventdata = Project.query.filter_by(event_id=event_id, is_hidden=False)
-    projects = eventdata.filter(Project.progress >= 0).order_by(Project.name)
-    challenges = eventdata.filter(Project.progress < 0).order_by(Project.name)
+    projects = eventdata.filter(Project.progress > 0).order_by(Project.name)
+    challenges = eventdata.filter(Project.progress <= 0).order_by(Project.id)
     return render_template('public/eventprint.html', active='print',
                            projects=projects, challenges=challenges,
                            current_event=event, curdate=now)

--- a/dribdat/public/views.py
+++ b/dribdat/public/views.py
@@ -154,7 +154,7 @@ def user(username):
 @login_required
 def user_post():
     """Redirect to a Post form for my current project."""
-    projects = current_user.joined_projects(False)
+    projects = current_user.joined_projects(True, 1)
     if not len(projects) > 0:
         flash('Please Join a project to be able to Post an update.', 'info')
         return redirect(url_for("public.home"))

--- a/dribdat/settings.py
+++ b/dribdat/settings.py
@@ -39,6 +39,7 @@ class Config(object):
     OAUTH_AUTH_URL = os_env.get('OAUTH_AUTH_URL', None)
     # (Optional) Go directly to external login screen
     OAUTH_SKIP_LOGIN = bool(strtobool(os_env.get('OAUTH_SKIP_LOGIN', 'False')))
+    OAUTH_LINK_REGISTER = os_env.get('OAUTH_LINK_REGISTER', None)
 
     # Mail service support
     MAIL_PORT = os_env.get('MAIL_PORT', 25)

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -757,7 +757,7 @@ nav .nav-login {
   display: block;
 }
 .tooltip .tooltip-inner span,
-.project-page .project-hashtag {
+.project-hashtag {
   font-weight: bold;
   font-size: 150%;
   color: red;
@@ -1982,42 +1982,41 @@ SlackIn button
 -------------- */
 
 .signin-slack {
-  font-size: 0px;
   border: 0px !important;
   background: url('/static/img/sso/slack-sign-in.png') no-repeat;
   width: 173px; height: 41px;
 }
 .signin-azure {
   border: 0px !important;
-  padding-left: 50px;
+  padding-left: 50px; font-size: initial !important;
   background: url('/static/img/sso/azure_teams.svg') no-repeat;
   width: auto; height: 41px;
 }
 .signin-github {
-  font-size: 0px; border: 0px !important;
+  border: 0px !important;
   background: url('/static/img/sso/github-sign-in.png') no-repeat;
   width: 372px; height: 64px;
 }
 .signin-auth0 {
-  font-size: 0px;
   border: 1px solid #999;
   background: url('/static/img/sso/auth0_icon.png') no-repeat;
   width: 156px; height: 71px;
 }
 .signin-mattermost {
   border: 1px solid #999;
-  font-size: 0px;
   background: url('/static/img/sso/Mattermost-Logo-Denim.svg') no-repeat;
   width: 190px; height: 43px;
 }
 .signin-hitobito {
   border: 1px solid #999;
-  font-size: 0px;
   background: url('/static/img/sso/hitobito.png') no-repeat;
   width: 260px; height: 58px;
 }
 .sso-login .btn:hover {
   border: 1px solid blue;
+}
+.sso-login .btn {
+  font-size: 0px;
 }
 .account-register a { margin-left: 3.5em; font-size: 125%; }
 .account-register::before,

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -752,12 +752,17 @@ nav .nav-login {
   hyphens: auto;
 }
 .tooltip .tooltip-inner span { /* Hashtag */
-  font-weight: bold;
-  font-size: 80%;
-  font-family: monospace;
   overflow: hidden;
   max-height: 1.5em;
   display: block;
+}
+.tooltip .tooltip-inner span,
+.project-page .project-hashtag {
+  font-weight: bold;
+  font-size: 150%;
+  color: red;
+  text-shadow: 1px 1px 1px white;
+  font-family: monospace;
 }
 .tooltip .tooltip-inner img {
   max-width: 100%;
@@ -1518,7 +1523,7 @@ a.go-up {
 .widget-team .kick-user {
   position: absolute;
   font-size: 150%;
-  margin-left: -2.2em;
+  margin-top: -1em;
 }
 .widget-team .kick-user:hover {
   font-weight: bold;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -599,7 +599,8 @@ nav .nav-login {
 }
 .team-counter {
   font-size: 13pt;
-  color: rgba(0,0,200,0.4);
+  color: whitesmoke;
+  text-shadow: 1px 1px 1px rgba(0,0,200,0.7);
   position: absolute;
   text-align: right;
   width: 94%;

--- a/dribdat/static/css/style.css
+++ b/dribdat/static/css/style.css
@@ -423,9 +423,11 @@ nav .nav-login {
   width: 100%;
   max-height: 100%;
 }
+.home-page .carousel-caption .event-header a {
+  text-decoration: none;
+}
 .home-page .carousel-caption .event-header .section-header-content {
   text-align: left;
-  text-decoration: none;
   color: initial;
   background: white;
   box-shadow: 3px 3px 3px rgba(0,0,0,0.2);
@@ -572,17 +574,17 @@ nav .nav-login {
 .hexagon.blank {
   visibility: hidden;
 }
-.project.hexagon:hover .hexagontent .team-count {
+.project.hexagon:hover .hexagontent .team-boost {
   display: inline-block;
 }
-.project.hexagon .hexagontent .team-count {
+.project.hexagon .hexagontent .team-boost {
   display: none;
   background: white;
   left: -3em; right: auto;
   top: 50%;
   margin-top: -1em;
 }
-.hexagon .hexagontent .team-count {
+.hexagon .hexagontent .team-boost {
   top: -1em;
   right: -1em;
   min-width: 2.5em;
@@ -591,6 +593,18 @@ nav .nav-login {
   font-size: 80%;
   background: rgba(255, 255, 255, 0.8);
   box-shadow: 0 4px 9px rgb(0 0 0 / 2%), 0 9px 15px rgb(0 0 0 / 7%);
+}
+.project.hexagon .team-counter {
+  color: white;
+}
+.team-counter {
+  font-size: 13pt;
+  color: rgba(0,0,200,0.4);
+  position: absolute;
+  text-align: right;
+  width: 94%;
+  bottom: 0.3em;
+  z-index: 99;
 }
 
 .project-page.phase-Challenge .progress,
@@ -1584,7 +1598,7 @@ a.go-up {
   margin-top: 1em;
   color: grey;
 }
-.team-count,
+.team-boost,
 .user-score {
   min-width: 2.5em;
   text-align: center;
@@ -1594,7 +1608,7 @@ a.go-up {
   border-radius: 2em;
   padding: 0.5em;
 }
-.project-score .team-count {
+.project-score .drib-count {
   font-size: 80%;
   margin-top: -0.5em;
   text-decoration: none;

--- a/dribdat/static/js/editor.js
+++ b/dribdat/static/js/editor.js
@@ -85,7 +85,6 @@
       vparent.show();
       all_checked = $('.form-project-confirm input[type="checkbox"]:not(:checked)').length === 0;
       vinput.checked = all_checked;
-      // $('#next-level-hint').hide();
     });
   });
 

--- a/dribdat/static/js/editor.js
+++ b/dribdat/static/js/editor.js
@@ -250,8 +250,13 @@
               $('#is_webembed:not(:checked)').click();
               $dialog.modal('hide');
             } else if ($(this).data('target') == 'pitch') {
+              // Determine file extension
+              //var fileExt = filename.split('.');
+              //fileExt = (fileExt.length > 1) ? fileExt[fileExt.length - 1] : '?';
+                  // ... ' (' + fileExt.toUpperCase() + ')';
+              // Create Markdown link with a paperclip emoji
+              var fileLink = '📎 [' + filename + '](' + response + ')'; 
               // Append to pitch
-              var fileLink = '📦 File: [' + filename + '](' + response + ')';
               if (typeof window.toasteditor !== 'undefined') {
                 window.toasteditor.insertText(fileLink);
               } else {

--- a/dribdat/static/js/notify.js
+++ b/dribdat/static/js/notify.js
@@ -40,7 +40,7 @@
   // Check the location, ignore the Dashboard
   if (location.href.indexOf('/dashboard')<0) {
     createNotification();
-    setInterval(createNotification, 30 * 1000); // check twice a minute
+    setInterval(createNotification, 60 * 1000); // check once a minute
 
     // To enable the popups, click the button in the footer
     $('#notification-button').show().click(function() {

--- a/dribdat/static/js/notify.js
+++ b/dribdat/static/js/notify.js
@@ -45,11 +45,18 @@
     // To enable the popups, click the button in the footer
     $('#notification-button').show().click(function() {
       //console.log('un-muting...');
+      $('#notifications-status-text').html('You will now receive alerts');
+      $('#global-notifications-alert').removeClass('hidden');
       localStorage.removeItem('eventstatus-mute');
       localStorage.removeItem('eventstatus');
       createNotification();
     });
 
   } // -no-dashboard
+
+  // Close button is just a hider
+  $('#global-notifications-alert .close').click(function() {
+    $('#global-notifications-alert').addClass('hidden');
+  });
 
 }).call(this, jQuery, window);

--- a/dribdat/static/js/render.js
+++ b/dribdat/static/js/render.js
@@ -5,7 +5,7 @@ let $thecanvas = $('#canv');
 let url = $thebody.attr('src');
 let pdfjsLib = window["pdfjs-dist/build/pdf"];
 
-pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.0.279/pdf.worker.min.js';
+pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.worker.min.js';
 
 var pdfDoc = null,
     pageNum = 1,

--- a/dribdat/templates/admin/events.html
+++ b/dribdat/templates/admin/events.html
@@ -62,16 +62,16 @@
             <td>
               <a href="{{ url_for('admin.event', event_id=event.id) }}" style="float:right">
               {% if event.is_current %}
-                <span class="btn btn-warning btn-sm">Current</span>
+                <span class="btn btn-success btn-sm">Current</span>
               {% endif %}
               {% if event.lock_editing %}
-                <span title="Editing locked" class="btn btn-dark btn-sm">Freeze</span>
+                <span title="Editing locked" class="btn btn-light btn-sm">Freeze</span>
               {% endif %}
               {% if event.lock_starting %}
-                <span title="Creating locked" class="btn btn-dark btn-sm">Lock</span>
+                <span title="Creating locked" class="btn btn-light btn-sm">Lock</span>
               {% endif %}
               {% if event.lock_resources %}
-                <span title="Projects are considered global resources" class="btn btn-dark btn-sm">Resource</span>
+                <span title="Projects are considered global resources" class="btn btn-warning btn-sm">Resource</span>
               {% endif %}
               {% if event.is_hidden %}
                 <span class="btn btn-dark btn-sm">Hidden</span>

--- a/dribdat/templates/admin/reset.html
+++ b/dribdat/templates/admin/reset.html
@@ -6,6 +6,8 @@
 <div class="container">
     <h2>New password</h2>
 
+    <p>The user password has been reset. If e-mail is enabled, they can request a password reset, or you can send them the new password directly - with a reminder to change it in the Profile!</p>
+
     <p style="background:#eee;padding:1em"><tt id="hidden" style="opacity:0">{{ newpw }}</tt></p>
 
     <a href="#" class="btn btn-warning"

--- a/dribdat/templates/admin/users.html
+++ b/dribdat/templates/admin/users.html
@@ -12,6 +12,9 @@
     <table class='table table-hover'>
         <thead>
             <tr>
+              <th title="Activity count">
+                Dribs
+              </th>
               <th width="100%">
                 <a href="?sort=username">Username</a>
                 <div style="float:right">
@@ -19,19 +22,17 @@
                 </div>
               </th>
               <th>
-                <a href="?sort=created">Created</a>
-              </th>
-              <th title="Activity count">
-                Dribs
+                <a href="?sort=created">Cre</a>/<a href="?sort=updated">Updated</a>
               </th>
               <th>
                 <a href="?sort=sso" title="Single Sign-on ?">SSO</a>
               </th>
-              <th>Actions</th>
+              <th></th>
             </tr>
         </thead>
         {% for user in data.items %}
         <tr>
+            <td>{{ user.activity_count }}</td>
             <td {% if not user.active %}style="background:yellow" title="Account inactive"{% endif %}>
               {% if user.is_admin %}
               <div style="float:right">
@@ -42,8 +43,7 @@
                 {{ user.username }}
               </a>   
             </td>
-            <td>{{ user.created_at|format_date }}</td>
-            <td>{{ user.activity_count }}</td>
+            <td>{{ user.created_at|format_date }}<br>{{ user.updated_at|format_date }}</td>
             <td>{% if user.sso_id %}&#10003;{% endif %}</td>
             <td><div class="btn-group">
               <a href="{{ url_for('admin.user', user_id=user.id) }}" class="btn btn-primary">

--- a/dribdat/templates/includes/eventhome.html
+++ b/dribdat/templates/includes/eventhome.html
@@ -35,24 +35,23 @@
     </div>
   {% endif %}
 
-  <!--
   <div class="home-nav">
     <div class="home-buttons" aria-label="Main navigation">
       <a href="{{ url_for('public.event', event_id=event.id) }}"
-         class="btn btn-lg btn-warning p-3">
+         class="btn btn-light">
+        {{ event.projects|count }}
         {% if event.has_finished %}
           <i class="fa fa-certificate" aria-hidden="true"></i>
-          All Results
+          <span>Results</span>
         {% elif event.has_started %}
-          <i class="fa fa-code" aria-hidden="true"></i>
-          All Projects
+          <i class="fa fa-cubes" aria-hidden="true"></i>
+          <span>Projects</span>
         {% else %}
-          <i class="fa fa-lightbulb-o" aria-hidden="true"></i>
-          All Challenges
+          <i class="fa fa-cubes" aria-hidden="true"></i>
+          <span>Challenges</span>
         {% endif %}
       </a>
     </div>
   </div>
-  -->
 
 </div><!-- /.event-header -->

--- a/dribdat/templates/includes/eventhome.html
+++ b/dribdat/templates/includes/eventhome.html
@@ -39,7 +39,7 @@
     <div class="home-buttons" aria-label="Main navigation">
       <a href="{{ url_for('public.event', event_id=event.id) }}"
          class="btn btn-light">
-        {{ event.projects|count }}
+        {{ event.project_count }}
         {% if event.has_finished %}
           <i class="fa fa-certificate" aria-hidden="true"></i>
           <span>Results</span>

--- a/dribdat/templates/includes/footer.html
+++ b/dribdat/templates/includes/footer.html
@@ -1,8 +1,8 @@
 <footer id="footer">
-  <a class="dribdat-logo" href="{{ url_for('public.home') }}">
+  <a class="dribdat-logo" href="{{ url_for('public.about') }}">
     <img src="{{ url_for('static', filename='img/logo11.png') }}">
   </a>
-  <a href="#" id="notification-button" class="hidden">
+  <a href="#top" id="notification-button" class="hidden ml-3">
     <i class="fa fa-bell" aria-hidden="true"></i>
     Alerts
   </a>
@@ -18,8 +18,8 @@
       {% endif %}
       <li>
         <a href="{{ url_for('public.user', username=current_user.username) }}" title="{{ current_user.username }}">
-          <i class="fa fa-key" aria-hidden="true"></i>
-          Account
+          <i class="fa fa-user" aria-hidden="true"></i>
+          Profile
         </a>
       </li>
       <li>

--- a/dribdat/templates/includes/nav.html
+++ b/dribdat/templates/includes/nav.html
@@ -59,20 +59,20 @@
 
       {% if current_user and current_user.is_authenticated %}
           <li class="nav-item">
-            <a id="project-post"
-               href="{{ url_for('public.user_post') }}"
-               title="Post an update to your current project" 
-               class="btn btn-light mt-2">
-              <i class="fa fa-paper-plane" aria-hidden="true"></i>
-              Post
-            </a>
-          </li>
-          <li class="nav-item">
             <a class="nav-link{{ ' active' if active == 'profile' }}" 
                title="Take me to my profile"
                href="{{ url_for('public.user', username=current_user.username) }}" title="{{ current_user.username }}">
               <i class="fa fa-user" aria-hidden="true"></i>
               Profile
+            </a>
+          </li>
+          <li class="nav-item">
+            <a id="project-post"
+               class="nav-link btn btn-secondary"
+               href="{{ url_for('public.user_post') }}"
+               title="Post an update to your current project">
+              <i class="fa fa-paper-plane" aria-hidden="true"></i>
+              Post
             </a>
           </li>
           {% if current_user.is_admin %}
@@ -132,7 +132,7 @@
 <!-- Popup global alerts -->
 <div id="global-notifications-alert" class="hidden">
   <div class="alert alert-info">
-    <a class="close" title="Close" href="#" data-dismiss="alert">&times;</a>
+    <a class="close" title="Close" href="#">&times;</a>
     <i class="fa fa-info-circle float-left" aria-hidden="true"></i>
     <span id="notifications-status-text"></span>
   </div>

--- a/dribdat/templates/includes/nav.html
+++ b/dribdat/templates/includes/nav.html
@@ -34,6 +34,14 @@
       </li>
       {% if event and not event.lock_resources %}
         <li class="nav-item">
+          <a class="nav-link {% if active == 'participants' %}active{% endif %}" 
+             title="Show me the people"
+             href="{{ url_for('public.event_participants', event_id=event.id) }}">
+            <i class="fa fa-child" aria-hidden="true"></i>
+            People
+          </a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link {% if active == 'projects' %}active{% endif %}" 
              title="Show me the projects"
              href="{{ url_for('public.event', event_id=event.id) }}#top">
@@ -47,23 +55,24 @@
             {% endif %}
           </a>
         </li>
-        <li class="nav-item">
-          <a class="nav-link {% if active == 'participants' %}active{% endif %}" 
-             title="Show me the people"
-             href="{{ url_for('public.event_participants', event_id=event.id) }}">
-            <i class="fa fa-child" aria-hidden="true"></i>
-            People
-          </a>
-        </li>
       {% endif %}
 
       {% if current_user and current_user.is_authenticated %}
           <li class="nav-item">
+            <a id="project-post"
+               href="{{ url_for('public.user_post') }}"
+               title="Post an update to your current project" 
+               class="btn btn-light mt-2">
+              <i class="fa fa-paper-plane" aria-hidden="true"></i>
+              Post
+            </a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link{{ ' active' if active == 'profile' }}" 
                title="Take me to my profile"
                href="{{ url_for('public.user', username=current_user.username) }}" title="{{ current_user.username }}">
-              <i class="fa fa-key" aria-hidden="true"></i>
-              Account
+              <i class="fa fa-user" aria-hidden="true"></i>
+              Profile
             </a>
           </li>
           {% if current_user.is_admin %}

--- a/dribdat/templates/includes/pagination.html
+++ b/dribdat/templates/includes/pagination.html
@@ -2,13 +2,13 @@
 {% if data.pages > 1 %}
 <div class="nav-pagination">
 	{% if data.has_prev %}
-		<a href="{{ url_for(endpoint, page=data.prev_num) }}" class="btn btn-secondary">&#9664;&nbsp; Previous</a>
+		<a href="{{ url_for(endpoint, page=data.prev_num, sort=sort_by) }}" class="btn btn-secondary">&#9664;&nbsp; Previous</a>
 	{% endif %}
 	<span class="pagination m-3" style="display:inline-block">
 	{%- for page in data.iter_pages() %}
 		{% if page %}
 			{% if page != data.page %}
-				<a href="{{ url_for(endpoint, page=page) }}">{{ page }}</a>
+				<a href="{{ url_for(endpoint, page=page, sort=sort_by) }}">{{ page }}</a>
 			{% else %}
 				<strong>{{ page }}</strong>
 			{% endif %}
@@ -18,7 +18,7 @@
 	{%- endfor %}
 	</span>
 	{% if data.has_next %}
-		<a href="{{ url_for(endpoint, page=data.next_num) }}" class="btn btn-secondary">Next &nbsp;&#9654;</a>
+		<a href="{{ url_for(endpoint, page=data.next_num, sort=sort_by) }}" class="btn btn-secondary">Next &nbsp;&#9654;</a>
 	{% endif %}
 </div>
 {% endif %}

--- a/dribdat/templates/macros/_event.html
+++ b/dribdat/templates/macros/_event.html
@@ -29,12 +29,10 @@
 		<div class="hexagontent {{
 	        'text-md' if 32 < project.name|length else 'text-sm' if 42 < project.name|length
 		}}{{ ' with-icon' if project.logo_icon or project.image_url }}">
-			{% if project.is_challenge and project.team %}
-				<span class="team-count" title="# following">{{ project.team|count }}</span>
-			{% elif project.score and project.score > 80 %}
-				<span class="team-count" title="Skyrocketing">🚀</span>
+			{% if project.score and project.score > 90 %}
+				<span class="team-boost" title="Skyrocketing">🚀</span>
 			{% elif project.score and project.score > 69 %}
-				<span class="team-count" title="Trending">🔥</span>
+				<span class="team-boost" title="Trending">🔥</span>
 			{% endif %}
 			<span class="project-name">{{ project.name|truncate(64, True, '..') }}</span>
 			{% if project.image_url %}
@@ -43,11 +41,22 @@
 				<div class="hexaicon"><i class="fa fa-{{project.logo_icon}}"></i></div>
 			{% endif %}
 		</div>
-		{% if project.score and project.score > 0 %}
-		<div class="progress">
-			<div class="progress-bar" role="progressbar" aria-valuenow="{{project.score}}" aria-valuemin="0" aria-valuemax="70" style="width:{{project.score}}%">
+		{% if project.team_count > 0 %}
+			<div class="team-counter" 
+					 title="{{ project.team|count }} supporting">
+				{% if project.team_count == 1 %}
+					<i class="fa fa-user"></i>
+				{% elif project.team_count == 2 %}
+					<i class="fa fa-user"></i><i class="fa fa-user"></i>
+				{% elif project.team_count > 2 %}
+					<i class="fa fa-users"></i>
+				{% endif %}
 			</div>
-		</div>
+		{% elif project.score and project.score > 0 %}
+			<div class="progress">
+				<div class="progress-bar" role="progressbar" aria-valuenow="{{project.score}}" aria-valuemin="0" aria-valuemax="70" style="width:{{project.score}}%">
+				</div>
+			</div>
 		{% endif %}
 	</a>
 {% endmacro %}
@@ -131,7 +140,6 @@
 			</div>
 	    <div class="card-body">
 	      {% if not event.lock_resources %}
-	        <!--<i class="fa fa-code" style="float:right"></i>-->
 		      <h3 class="card-title">
 		        <a href="{{ url_for('public.event', event_id=event.id) }}">
 		          {{event.name}}</a>
@@ -155,7 +163,7 @@
 	      <div class="an-event-actions text-center">
 	        {% if event.lock_resources %}
 	            <a href="{{ url_for('public.event_stages', event_id=event.id) }}" class="btn btn-lg btn-warning">
-								<i class="fa fa-cubes" aria-hidden="true"></i>
+								<i class="fa fa-codepen" aria-hidden="true"></i>
                 {{event.name}}
 	            </a>
 	        {% elif event.has_finished %}
@@ -165,7 +173,7 @@
 	            </a>
 	        {% else %}
 	            <a href="{{ url_for('public.event', event_id=event.id) }}" class="btn btn-lg btn-success">
-      					<i class="fa fa-code" aria-hidden="true"></i>
+      					<i class="fa fa-cubes" aria-hidden="true"></i>
 	              Challenges
 	            </a>
 	        {% endif %}

--- a/dribdat/templates/public/dashboard.html
+++ b/dribdat/templates/public/dashboard.html
@@ -42,13 +42,13 @@
     <div class="col-md-3">
     </div>
 
-    <div class="col-md-3" style="padding:0px">
+    <div class="col-md-3 socialwall">
         <div id="activities"></div>
 
     {% if with_social_wall == 'twitter' %}
-      <a class="twitter-timeline" data-width="340" data-height="900" data-dnt="true" data-theme="dark" data-link-color="#E95F28" href="{{ current_event.community_url }}">Tweets</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+      <a class="twitter-timeline" data-width="340" data-height="900" data-dnt="true" data-theme="light" data-link-color="#E95F28" href="{{ current_event.community_url }}">Tweets</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     {% elif with_social_wall == 'mastodon' %}
-      <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="100%" height="100%" src="https://www.mastofeed.com/apiv2/feed?userurl={{ wall_url }}&theme=dark&size=100&header=false&replies=false&boosts=true"></iframe>
+      <iframe allowfullscreen sandbox="allow-top-navigation allow-scripts allow-popups allow-popups-to-escape-sandbox" width="100%" height="67%" src="https://www.mastofeed.com/apiv2/feed?userurl={{ wall_url }}&theme=light&size=100&header=false&replies=false&boosts=true" frameborder="0"></iframe>
     {% endif %}
     </div>
   </div>
@@ -66,13 +66,13 @@
     background-size: cover;
     background-repeat: no-repeat;
     background-image: url('{{ current_event.gallery_url }}');
+    font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   }
   .hidden {
     display: none;
   }
   #projects {
-    color: #fff;
-    font: 15pt sans-serif;
+    font-size: 14pt;
     overflow: hidden;
     list-style-type: none;
     padding: 0px;
@@ -110,13 +110,18 @@
   .container-fluid .sidebar {
     height: 100%;
     position: fixed;
-    background-color: black !important;
-    opacity: 0.7;
+    background-color: #ddd;
+  }
+
+  .container-fluid .socialwall {
+    padding: 0px;
+    background: #fff;
   }
 
   #event-logo {
-    width: 175%;
+    width: 50%;
     margin-top: 100px;
+    position: fixed;
   }
   #event-logo img {
     border-radius: 10px;
@@ -134,11 +139,12 @@
   #schedule > * { display: none; }
 
   #announcements {
-    position: absolute;
-    top: 10%;
+    position: fixed;
+    top: 26%;
     left: 22%;
     /*left: 50%;
     margin-left: -15em;*/
+    z-index: 999;
   }
 
   #announcements button {
@@ -147,7 +153,7 @@
   }
 
   #announcements textarea {
-    width: 12em;
+    width: 18em;
     height: 4em;
     font-size: 50px;
     font-weight: bold;
@@ -159,8 +165,8 @@
     border-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='100' height='100' viewBox='0 0 100 100' fill='none' xmlns='http://www.w3.org/2000/svg'%3E %3Cstyle%3Epath%7Banimation:stroke 5s infinite linear%3B%7D%40keyframes stroke%7Bto%7Bstroke-dashoffset:776%3B%7D%7D%3C/style%3E%3ClinearGradient id='g' x1='0%25' y1='0%25' x2='0%25' y2='100%25'%3E%3Cstop offset='0%25' stop-color='%232d3561' /%3E%3Cstop offset='25%25' stop-color='%23c05c7e' /%3E%3Cstop offset='50%25' stop-color='%23f3826f' /%3E%3Cstop offset='100%25' stop-color='%23ffb961' /%3E%3C/linearGradient%3E %3Cpath d='M1.5 1.5 l97 0l0 97l-97 0 l0 -97' stroke-linecap='square' stroke='url(%23g)' stroke-width='3' stroke-dasharray='388'/%3E %3C/svg%3E") 1;
   }
   .superpowers {
-    position: absolute;
-    bottom: 0px; right: 0px;
+    position: fixed;
+    bottom: 0px; right: 50%;
     z-index: 999;
   }
   .superpowers button {
@@ -231,6 +237,7 @@ refreshProjects = function() {
   $.getJSON('/api/event/current/projects.json', function(data) {
     $pp = $('#projects').empty();
     data.projects.forEach(function(p) {
+      if (p.is_hidden) return;
       $pp.append('<div>' +
         '<a href="/project/'+p.id+'">'+p.name+'</a>' +
         '<sp style="width:'+p.score+'px"></sp>' +

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -91,7 +91,7 @@
   {% if current_event.can_start_project %}
   <a href="{{ url_for('project.project_new', event_id=current_event.id) }}" class="btn btn-lg btn-success">
     {% if current_event.lock_resources %}
-      <i class="fa fa-cubes"></i>
+      <i class="fa fa-codepen"></i>
       <span>Share a resource</span>
     {% elif current_event.has_started %}
       <i class="fa fa-rocket"></i>

--- a/dribdat/templates/public/event.html
+++ b/dribdat/templates/public/event.html
@@ -196,7 +196,7 @@
   {% endif %}
 
   {% if config.DRIBDAT_SOCIAL_LINKS %}
-    {{ social.share_links(current_event.hashtag, url_for('public.event', event_id=current_event.id, _external=True)) }}
+    {{ social.share_links(current_event.hashtags, url_for('public.event', event_id=current_event.id, _external=True)) }}
   {% endif %}
 </center>
 {% endblock %}

--- a/dribdat/templates/public/eventprint.html
+++ b/dribdat/templates/public/eventprint.html
@@ -76,7 +76,7 @@
       <br clear="all">
       <div class="project-page clear-both">
         <div class="project-longtext">
-          {{project.longtext|markdown}}
+          {{project.longtext|markdown|safe}}
         </div>
       </div>
     {% endif %}
@@ -132,9 +132,11 @@
         {{project.summary}}
       </p>
     {% else %}
-      <div class="project-longtext">
-        {{project.longtext|truncate(250)|markdown}}
-      </div>
+      {% if request.args.get('longtext') and project.longtext %}
+        <div class="project-longtext">
+          {{project.longtext|markdown|safe}}
+        </div>
+      {% endif %}
     {% endif %}
   </div>
 

--- a/dribdat/templates/public/eventprint.html
+++ b/dribdat/templates/public/eventprint.html
@@ -27,7 +27,7 @@
   <div class="project-info">
 
     <ul class="project-meta">
-      <li>Permalink: <a href="{{ url_for('project.project_view', project_id=project.id) }}">{{ url_for('project.project_view', project_id=project.id, _external=True) }}</a></li>
+      <li><a href="{{ url_for('project.project_view', project_id=project.id) }}">{{ url_for('project.project_view', project_id=project.id, _external=True) }}</a></li>
       {% if project.webpage_url %}
       <li>Homepage: <a href="{{ project.webpage_url }}">{{ project.webpage_url|truncate(50) }}</a></li>
       {% endif %}
@@ -52,6 +52,10 @@
 
     {% if project.image_url %}
       <img align="right" hspace="10" class="project-image" width="128" src="{{project.image_url}}">
+    {% endif %}
+
+    {% if project.hashtag %}
+    <p class="project-hashtag m-0 p-0">{{project.hashtag}}</p>
     {% endif %}
 
     <h2 style="font-weight:bold">
@@ -110,6 +114,11 @@
       <li>Category: <b>{{ project.category.name }}</b></li>
       {% endif %}
     </ul>
+
+    {% if project.hashtag %}
+    <p class="project-hashtag m-0 p-0">{{project.hashtag}}</p>
+    {% endif %}
+    
     <h2 style="font-weight:bold">
       {% if project.logo_icon %}
         <i class="fa fa-{{project.logo_icon}}"></i>

--- a/dribdat/templates/public/login.html
+++ b/dribdat/templates/public/login.html
@@ -7,6 +7,13 @@
 <div class="container-narrow">
   <h1>Log in</h1>
   <br/>
+
+  {% if oauth_type %}
+    <p>
+      Use the button below to sign in with your {{ oauth_type|capitalize }} account.
+    </p>
+  {% endif %}
+  
   {% if oauth_type == 'slack' %}
     <p class="sso-login">
       <a class="btn signin-slack" href="{{ url_for('slack.login') }}" title="Sign in with Slack">
@@ -44,6 +51,7 @@
       </a>
     </p>
   {% endif %}
+
   <form id="loginForm" method="POST" action="/login/" role="login" class="navbar-form form-inline">
     {{ form.hidden_tag() }}
     <div class="form-group">

--- a/dribdat/templates/public/login.html
+++ b/dribdat/templates/public/login.html
@@ -71,5 +71,10 @@
       <a class="btn btn-warning btn-submit" href="{{ url_for('auth.register') }}">Create an account</a>
     </p>
   {% endif %}
+  {% if config.OAUTH_LINK_REGISTER %}
+    <p class="account-register">
+      <a class="btn btn-warning btn-submit" href="{{ config.OAUTH_LINK_REGISTER }}">Register for an account</a>
+    </p>
+  {% endif %}
 </div>
 {% endblock %}

--- a/dribdat/templates/public/project.html
+++ b/dribdat/templates/public/project.html
@@ -138,7 +138,7 @@
 
   {% if project.score and project.score > 1 %}
     <div class="project-score">
-      <a class="team-count float-left mr-2" title="Drib count" href="#logs"
+      <a class="drib-count float-left mr-2" title="Drib count" href="#logs"
          onclick="$('#dribs-tab-md').click();">{{ project_dribs|length }}</a>
 
       <a href="{{ url_for('public.event_stages', event_id=project.event.id) }}#{{project.phase}}">
@@ -168,7 +168,7 @@
   {% if project.event.lock_resources %}
   <a href="{{ url_for('public.event_stages', event_id=project.event.id) }}"
      class="btn btn-light mr-4 float-right">
-       <i class="fa fa-cubes" aria-hidden="true"></i>
+       <i class="fa fa-codepen" aria-hidden="true"></i>
        Resource</a>
   {% endif %}
 
@@ -213,12 +213,22 @@
     {% endif %}
     {% if project.autotext %}
     <li class="nav-item">
-      <a class="nav-link" id="readme-tab-md" href="#readme-md">Readme</a>
+      <a class="nav-link" id="readme-tab-md" href="#readme-md">
+        <i class="fa fa-book"></i>
+        Readme</a>
     </li>
     {% endif %}
     {% if project_team %}
     <li class="nav-item">
-      <a class="nav-link" id="dribs-tab-md" href="#team">Team</a>
+      <a class="nav-link" id="dribs-tab-md" href="#team">
+        {% if project.team_count == 1 %}
+          <i class="fa fa-user"></i>
+        {% elif project.team_count == 2 %}
+          <i class="fa fa-user"></i><i class="fa fa-user"></i>
+        {% elif project.team_count > 2 %}
+          <i class="fa fa-users"></i>
+        {% endif %}
+        Team</a>
     </li>
     {% endif %}
     {% if project_dribs %}

--- a/dribdat/templates/public/project.html
+++ b/dribdat/templates/public/project.html
@@ -208,19 +208,22 @@
   <ul class="nav nav-pills nav-fill md-tabs" id="projectTabs" role="tablist">
     {% if project.longtext %}
     <li class="nav-item">
-      <a class="nav-link" id="project-tab-md" href="#project-md">Pitch</a>
+      <a class="nav-link" id="project-tab-md" href="#project-md"
+         title="The description of a challenge or a solution">Pitch</a>
     </li>
     {% endif %}
     {% if project.autotext %}
     <li class="nav-item">
-      <a class="nav-link" id="readme-tab-md" href="#readme-md">
+      <a class="nav-link" id="readme-tab-md" href="#readme-md"
+         title="Content preview from an external site">
         <i class="fa fa-book"></i>
         Readme</a>
     </li>
     {% endif %}
     {% if project_team %}
     <li class="nav-item">
-      <a class="nav-link" id="dribs-tab-md" href="#team">
+      <a class="nav-link" id="dribs-tab-md" href="#team" 
+         title="Meet the family">
         {% if project.team_count == 1 %}
           <i class="fa fa-user"></i>
         {% elif project.team_count == 2 %}
@@ -233,7 +236,8 @@
     {% endif %}
     {% if project_dribs %}
     <li class="nav-item">
-      <a class="nav-link" id="dribs-tab-md" href="#dribs-md">Log</a>
+      <a class="nav-link" id="dribs-tab-md" href="#dribs-md"
+         title="Play by play progress review">Log</a>
     </li>
     {% endif %}
   </ul>
@@ -274,19 +278,20 @@
 
   {% if project.autotext %}
     <div id="readme-md" aria-labelledby="readme-tab-md">
+      
+      <div class="project-autotext"><div class="cover"></div>
+        {{project.autotext|markdown}}
+      </div>
+
       {% if not project.event.lock_resources %}
-        <div class="alert alert-secondary text-center">
+        <div class="alert alert-light text-center">
           This content is a preview from an
           <a href="{{ project.autotext_url }}" target="_blank" rel="noopener noreferrer" title="Source link">
             external site</a>.
         </div>
       {% endif %}
 
-      <div class="project-autotext"><div class="cover"></div>
-        {{project.autotext|markdown}}
-      </div>
-
-      <a href="#top" class="go-up" title="Scroll up">▲ 🆙</a>
+      <a href="#top" class="go-up" title="Scroll up!">▲▲▲</a>
     </div>
   {% endif %}
 
@@ -330,7 +335,7 @@
     </div>
   {% endif %}
 
-  <div class="project-buttons" role="group" aria-label="Main navigation">
+  <div class="project-buttons mb-5" role="group" aria-label="Main navigation">
     {% if project.contact_url %}
       {% if project.contact_url.startswith('http') or project.contact_url.startswith('mailto:') %}
         <a href="{{ project.contact_url }}" target="_blank" rel="noopener noreferrer" class="btn btn-lg" title="Contact the team"><span>&#x1f44b;</span> Contact</a>
@@ -406,7 +411,7 @@
 
     </section>
 
-    <a href="#top" class="go-up" title="Scroll up">▲ 🆙</a>
+    <a href="#top" class="go-up" title="Scroll up!">▲▲▲</a>
   </div><!-- /dribs-md -->
   {% endif %}
 

--- a/dribdat/templates/public/projectedit.html
+++ b/dribdat/templates/public/projectedit.html
@@ -7,8 +7,8 @@
 
 {% block js %}
   {% if config.ENV == 'prod' %}
-    <script src="https://uicdn.toast.com/editor/3.0.0/toastui-editor-all.min.js"></script>
-    <link href="https://uicdn.toast.com/editor/3.0.0/toastui-editor.min.css" rel="stylesheet">
+    <script src="https://uicdn.toast.com/editor/3.2.2/toastui-editor-all.min.js"></script>
+    <link href="https://uicdn.toast.com/editor/3.2.2/toastui-editor.min.css" rel="stylesheet">
   {% else %}
     <script src="{{ url_for('static', filename='libs/toastui-all/toastui-editor-all.min.js')}}"></script>
     <link href="{{ url_for('static', filename='libs/toastui-editor/dist/toastui-editor.css')}}" rel="stylesheet">

--- a/dribdat/templates/public/projectpost.html
+++ b/dribdat/templates/public/projectpost.html
@@ -18,7 +18,7 @@
 
   {% if all_valid %}
     <div class="form-project-confirm alert alert-default mb-3" role="alert">
-      <h5 class="mt-0" id="next-level-hint">&#128640;&nbsp;
+      <h5 class="mt-0 font-weight-bold" id="next-level-hint">&#128640;&nbsp;
         Ready for the next level?
       </h5>
       <label><input type="checkbox">

--- a/dribdat/templates/render.html
+++ b/dribdat/templates/render.html
@@ -10,9 +10,9 @@
 {% else %}
   <script src="{{ url_for('static', filename='libs/jquery/jquery.js')}}"></script>
 {% endif %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.0.279/pdf.min.js" integrity="sha512-QJy1NRNGKQoHmgJ7v+45V2uDbf2me+xFoN9XewaSKkGwlqEHyqLVaLtVm93FzxVCKnYEZLFTI4s6v0oD0FbAlw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.0.279/pdf_viewer.js" integrity="sha512-cTipoNt3ZJb0aCg4YxGXnPemVwETEvAxtil6RSQsSUJDUU3hk/zdf7tsqvefbJDxgaKafadU2v3smQyX91dvaw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.0.279/pdf_viewer.min.css" integrity="sha512-bhJalmRVg29JjmI5PVxobJ3xL71iUqk9yXhGjEtpuBg1tZ9LZZKF7Bdm8u6JifzvnxnsCB/PR9tZzmNEDE/BvQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js" integrity="sha512-QJy1NRNGKQoHmgJ7v+45V2uDbf2me+xFoN9XewaSKkGwlqEHyqLVaLtVm93FzxVCKnYEZLFTI4s6v0oD0FbAlw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf_viewer.js" integrity="sha512-cTipoNt3ZJb0aCg4YxGXnPemVwETEvAxtil6RSQsSUJDUU3hk/zdf7tsqvefbJDxgaKafadU2v3smQyX91dvaw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf_viewer.min.css" integrity="sha512-bhJalmRVg29JjmI5PVxobJ3xL71iUqk9yXhGjEtpuBg1tZ9LZZKF7Bdm8u6JifzvnxnsCB/PR9tZzmNEDE/BvQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 </head>
 <body class="render" src="{{ render_src }}">
@@ -47,8 +47,19 @@
   }
   .btn-group {
     position: absolute;
-    right: 1px;
+    right: 4px;
     top: 1px;
+    font-size: 130%;
+  }
+  .btn-group button {
+    border-style: dashed;
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.4;
+  }
+  .btn-group button:hover {
+    border-color: firebrick;
+    opacity: 1;
   }
 </style>
 </html>

--- a/dribdat/templates/render.html
+++ b/dribdat/templates/render.html
@@ -10,9 +10,10 @@
 {% else %}
   <script src="{{ url_for('static', filename='libs/jquery/jquery.js')}}"></script>
 {% endif %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js" integrity="sha512-QJy1NRNGKQoHmgJ7v+45V2uDbf2me+xFoN9XewaSKkGwlqEHyqLVaLtVm93FzxVCKnYEZLFTI4s6v0oD0FbAlw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf_viewer.js" integrity="sha512-cTipoNt3ZJb0aCg4YxGXnPemVwETEvAxtil6RSQsSUJDUU3hk/zdf7tsqvefbJDxgaKafadU2v3smQyX91dvaw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf_viewer.min.css" integrity="sha512-bhJalmRVg29JjmI5PVxobJ3xL71iUqk9yXhGjEtpuBg1tZ9LZZKF7Bdm8u6JifzvnxnsCB/PR9tZzmNEDE/BvQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js" integrity="sha512-ml/QKfG3+Yes6TwOzQb7aCNtJF4PUyha6R3w8pSTo/VJSywl7ZreYvvtUso7fKevpsI+pYVVwnu82YO0q3V6eg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf_viewer.min.js" integrity="sha512-OYwwL8rCrNapravkfWZCOWW0e/pC21Xnr9RmSVFIT/VAk0RZ3k4y4JAHUnsship8j3/9fKLB+CNizi4u7T5I9A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf_viewer.min.css" integrity="sha512-D0AR/C3senawQDjjZ7zvDnl3cTn8xe1m41gnJ6f4qmZrZpNA4kYR0OoVXFc/hQBXBd308Ho6wi9PG8IrmmshDg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 </head>
 <body class="render" src="{{ render_src }}">

--- a/dribdat/templates/render.html
+++ b/dribdat/templates/render.html
@@ -60,6 +60,7 @@
   }
   .btn-group button:hover {
     border-color: firebrick;
+    background: white;
     opacity: 1;
   }
 </style>

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -175,12 +175,13 @@ class User(UserMixin, PkModel):
         if limit < 0:
             activities = activities.all()
         else:
-            activities = activities.limit(limit)
+            activities = activities.limit(limit * 2)
         projects = []
         for a in activities:
             if a.project not in projects and not a.project.is_hidden:
                 if with_challenges or a.project.progress != 0:
-                    projects.append(a.project)
+                    if len(projects) < limit:
+                        projects.append(a.project)
         return projects
 
     def posted_challenges(self):

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -487,7 +487,7 @@ class Event(PkModel):
         """Return number of projects."""
         if not self.projects:
             return 0
-        return len(self.projects)
+        return self.projects.filter(not Project.is_hidden).count()
 
     def categories_for_event(self):
         """Event categories."""

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -616,9 +616,10 @@ class Project(PkModel):
             'id': self.id,
             'url': self.url,
             'name': self.name,
-            'team': self.team,
             'score': self.score,
             'phase': self.phase,
+            'team': self.team,
+            'team_count': self.team_count,
             'is_challenge': self.is_challenge,
             'is_webembed': self.is_webembed,
             'progress': self.progress,
@@ -668,13 +669,22 @@ class Project(PkModel):
         q = q.order_by(Activity.timestamp.desc())
         return q.limit(max)
 
+    @property
+    def team_count(self):
+        """Return follower count."""
+        return Activity.query \
+                .filter_by(project_id=self.id, name='star') \
+                .count()
+
     def get_team(self, with_spectators=False):
         """Return all starring users (A team)."""
-        q = Activity.query.filter_by(project_id=self.id)
+        activities = self.activities
         if with_spectators:
-            activities = q.all()
+            activities = self.activities
         else:
-            activities = q.filter_by(name='star').all()
+            activities = Activity.query \
+                .filter_by(project_id=self.id, name='star') \
+                .all()
         members = []
         for a in activities:
             if a.user and a.user not in members:

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -481,13 +481,13 @@ class Event(PkModel):
                     return ''
         return status_text
     
-
     @property
     def project_count(self):
-        """Return number of projects."""
+        """Number of active projects in an event."""
         if not self.projects:
             return 0
-        return self.projects.filter(not Project.is_hidden).count()
+        return Project.query \
+               .filter_by(event_id=self.id, is_hidden=False).count()
 
     def categories_for_event(self):
         """Event categories."""

--- a/dribdat/user/models.py
+++ b/dribdat/user/models.py
@@ -171,17 +171,15 @@ class User(UserMixin, PkModel):
         """Retrieve all projects user has joined."""
         activities = Activity.query.filter_by(
                 user_id=self.id, name='star'
-            ).order_by(Activity.timestamp.desc())
-        if limit < 0:
-            activities = activities.all()
-        else:
-            activities = activities.limit(limit * 2)
+            ).order_by(Activity.timestamp.desc()).all()
         projects = []
+        project_ids = []
         for a in activities:
-            if a.project not in projects and not a.project.is_hidden:
-                if with_challenges or a.project.progress != 0:
-                    if len(projects) < limit:
-                        projects.append(a.project)
+            if limit > 0 and len(projects) >= limit: continue
+            if a.project_id not in project_ids and not a.project.is_hidden:
+                if with_challenges or a.project.progress > 0:
+                    projects.append(a.project)
+                    project_ids.append(a.project_id)
         return projects
 
     def posted_challenges(self):

--- a/poetry.lock
+++ b/poetry.lock
@@ -223,7 +223,7 @@ toml = ["toml"]
 
 [[package]]
 name = "cryptography"
-version = "39.0.2"
+version = "40.0.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "dev"
 optional = false
@@ -235,10 +235,10 @@ cffi = ">=1.12"
 [package.extras]
 docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
 docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
-pep8test = ["black", "ruff", "mypy", "types-pytz", "types-requests", "check-manifest"]
+pep8test = ["black", "ruff", "mypy", "check-manifest"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["pytest (>=6.2.0)", "pytest-shard (>=0.1.2)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["pytest (>=6.2.0)", "pytest-shard (>=0.1.2)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601"]
 test-randomorder = ["pytest-randomly"]
 tox = ["tox"]
 
@@ -323,7 +323,7 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "18.3.0"
+version = "18.3.1"
 description = "Faker is a Python package that generates fake data for you."
 category = "dev"
 optional = false
@@ -1109,14 +1109,14 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyopenssl"
-version = "23.0.0"
+version = "23.1.0"
 description = "Python wrapper module around the OpenSSL library"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-cryptography = ">=38.0.0,<40"
+cryptography = ">=38.0.0,<41"
 
 [package.extras]
 docs = ["sphinx (!=5.2.0,!=5.2.0.post0)", "sphinx-rtd-theme"]
@@ -1216,7 +1216,7 @@ unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pytz"
-version = "2022.7.1"
+version = "2023.2"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -1846,29 +1846,25 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 cryptography = [
-    {file = "cryptography-39.0.2-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:2725672bb53bb92dc7b4150d233cd4b8c59615cd8288d495eaa86db00d4e5c06"},
-    {file = "cryptography-39.0.2-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:23df8ca3f24699167daf3e23e51f7ba7334d504af63a94af468f468b975b7dd7"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:eb40fe69cfc6f5cdab9a5ebd022131ba21453cf7b8a7fd3631f45bbf52bed612"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc0521cce2c1d541634b19f3ac661d7a64f9555135e9d8af3980965be717fd4a"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:e8a0772016feeb106efd28d4a328e77dc2edae84dfbac06061319fdb669ff828"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8f35c17bd4faed2bc7797d2a66cbb4f986242ce2e30340ab832e5d99ae60e011"},
-    {file = "cryptography-39.0.2-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b49a88ff802e1993b7f749b1eeb31134f03c8d5c956e3c125c75558955cda536"},
-    {file = "cryptography-39.0.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:5f8c682e736513db7d04349b4f6693690170f95aac449c56f97415c6980edef5"},
-    {file = "cryptography-39.0.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:d7d84a512a59f4412ca8549b01f94be4161c94efc598bf09d027d67826beddc0"},
-    {file = "cryptography-39.0.2-cp36-abi3-win32.whl", hash = "sha256:c43ac224aabcbf83a947eeb8b17eaf1547bce3767ee2d70093b461f31729a480"},
-    {file = "cryptography-39.0.2-cp36-abi3-win_amd64.whl", hash = "sha256:788b3921d763ee35dfdb04248d0e3de11e3ca8eb22e2e48fef880c42e1f3c8f9"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d15809e0dbdad486f4ad0979753518f47980020b7a34e9fc56e8be4f60702fac"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:50cadb9b2f961757e712a9737ef33d89b8190c3ea34d0fb6675e00edbe35d074"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:103e8f7155f3ce2ffa0049fe60169878d47a4364b277906386f8de21c9234aa1"},
-    {file = "cryptography-39.0.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:6236a9610c912b129610eb1a274bdc1350b5df834d124fa84729ebeaf7da42c3"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e944fe07b6f229f4c1a06a7ef906a19652bdd9fd54c761b0ff87e83ae7a30354"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:35d658536b0a4117c885728d1a7032bdc9a5974722ae298d6c533755a6ee3915"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl", hash = "sha256:30b1d1bfd00f6fc80d11300a29f1d8ab2b8d9febb6ed4a38a76880ec564fae84"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e029b844c21116564b8b61216befabca4b500e6816fa9f0ba49527653cae2108"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:fa507318e427169ade4e9eccef39e9011cdc19534f55ca2f36ec3f388c1f70f3"},
-    {file = "cryptography-39.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:8bc0008ef798231fac03fe7d26e82d601d15bd16f3afaad1c6113771566570f3"},
-    {file = "cryptography-39.0.2.tar.gz", hash = "sha256:bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f"},
+    {file = "cryptography-40.0.1-cp36-abi3-macosx_10_12_universal2.whl", hash = "sha256:918cb89086c7d98b1b86b9fdb70c712e5a9325ba6f7d7cfb509e784e0cfc6917"},
+    {file = "cryptography-40.0.1-cp36-abi3-macosx_10_12_x86_64.whl", hash = "sha256:9618a87212cb5200500e304e43691111570e1f10ec3f35569fdfcd17e28fd797"},
+    {file = "cryptography-40.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a4805a4ca729d65570a1b7cac84eac1e431085d40387b7d3bbaa47e39890b88"},
+    {file = "cryptography-40.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63dac2d25c47f12a7b8aa60e528bfb3c51c5a6c5a9f7c86987909c6c79765554"},
+    {file = "cryptography-40.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0a4e3406cfed6b1f6d6e87ed243363652b2586b2d917b0609ca4f97072994405"},
+    {file = "cryptography-40.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1e0af458515d5e4028aad75f3bb3fe7a31e46ad920648cd59b64d3da842e4356"},
+    {file = "cryptography-40.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:d8aa3609d337ad85e4eb9bb0f8bcf6e4409bfb86e706efa9a027912169e89122"},
+    {file = "cryptography-40.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cf91e428c51ef692b82ce786583e214f58392399cf65c341bc7301d096fa3ba2"},
+    {file = "cryptography-40.0.1-cp36-abi3-win32.whl", hash = "sha256:650883cc064297ef3676b1db1b7b1df6081794c4ada96fa457253c4cc40f97db"},
+    {file = "cryptography-40.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:a805a7bce4a77d51696410005b3e85ae2839bad9aa38894afc0aa99d8e0c3160"},
+    {file = "cryptography-40.0.1-pp38-pypy38_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cd033d74067d8928ef00a6b1327c8ea0452523967ca4463666eeba65ca350d4c"},
+    {file = "cryptography-40.0.1-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d36bbeb99704aabefdca5aee4eba04455d7a27ceabd16f3b3ba9bdcc31da86c4"},
+    {file = "cryptography-40.0.1-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:32057d3d0ab7d4453778367ca43e99ddb711770477c4f072a51b3ca69602780a"},
+    {file = "cryptography-40.0.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:f5d7b79fa56bc29580faafc2ff736ce05ba31feaa9d4735048b0de7d9ceb2b94"},
+    {file = "cryptography-40.0.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7c872413353c70e0263a9368c4993710070e70ab3e5318d85510cc91cce77e7c"},
+    {file = "cryptography-40.0.1-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:28d63d75bf7ae4045b10de5413fb1d6338616e79015999ad9cf6fc538f772d41"},
+    {file = "cryptography-40.0.1-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6f2bbd72f717ce33100e6467572abaedc61f1acb87b8d546001328d7f466b778"},
+    {file = "cryptography-40.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:cc3a621076d824d75ab1e1e530e66e7e8564e357dd723f2533225d40fe35c60c"},
+    {file = "cryptography-40.0.1.tar.gz", hash = "sha256:2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472"},
 ]
 cssmin = [
     {file = "cssmin-0.2.0.tar.gz", hash = "sha256:e012f0cc8401efcf2620332339011564738ae32be8c84b2e43ce8beaec1067b6"},
@@ -1895,8 +1891,8 @@ factory-boy = [
     {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
 ]
 faker = [
-    {file = "Faker-18.3.0-py3-none-any.whl", hash = "sha256:2deeee8fed3d1b8ae5f87d172d4569ddc859aab8693f7cd68eddc5d20400563a"},
-    {file = "Faker-18.3.0.tar.gz", hash = "sha256:e7c058e1f360f245f265625b32d3189d7229398ad80a8b6bac459891745de052"},
+    {file = "Faker-18.3.1-py3-none-any.whl", hash = "sha256:4c98c42984db54be2246d40e6407cd983db7b1511a70eaff64c3f383a51bace6"},
+    {file = "Faker-18.3.1.tar.gz", hash = "sha256:9bd71833146b844d848791b79720c7806108130c9603c7074123b3f77b4e97a1"},
 ]
 flake8 = []
 flake8-blind-except = [
@@ -2323,8 +2319,8 @@ pygments = [
     {file = "Pygments-2.14.0.tar.gz", hash = "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297"},
 ]
 pyopenssl = [
-    {file = "pyOpenSSL-23.0.0-py3-none-any.whl", hash = "sha256:df5fc28af899e74e19fccb5510df423581047e10ab6f1f4ba1763ff5fde844c0"},
-    {file = "pyOpenSSL-23.0.0.tar.gz", hash = "sha256:c1cc5f86bcacefc84dada7d31175cae1b1518d5f60d3d0bb595a67822a868a6f"},
+    {file = "pyOpenSSL-23.1.0-py3-none-any.whl", hash = "sha256:fb96e936866ad65662c22d0de84ca0fba58397893cdfe0f01334fa93382af23c"},
+    {file = "pyOpenSSL-23.1.0.tar.gz", hash = "sha256:8cb78010a1eb2c8e24b851693b7b04dfe9b1dc0a5ab3843927b10a85b1dfbb2e"},
 ]
 pyquery = []
 pyrsistent = []
@@ -2348,8 +2344,8 @@ python-slugify = [
     {file = "python_slugify-8.0.1-py2.py3-none-any.whl", hash = "sha256:70ca6ea68fe63ecc8fa4fcf00ae651fc8a5d02d93dcd12ae6d4fc7ca46c4d395"},
 ]
 pytz = [
-    {file = "pytz-2022.7.1-py2.py3-none-any.whl", hash = "sha256:78f4f37d8198e0627c5f1143240bb0206b8691d8d7ac6d78fee88b78733f8c4a"},
-    {file = "pytz-2022.7.1.tar.gz", hash = "sha256:01a0681c4b9684a28304615eba55d1ab31ae00bf68ec157ec3708a8182dbbcd0"},
+    {file = "pytz-2023.2-py2.py3-none-any.whl", hash = "sha256:8a8baaf1e237175b02f5c751eea67168043a749c843989e2b3015aa1ad9db68b"},
+    {file = "pytz-2023.2.tar.gz", hash = "sha256:a27dcf612c05d2ebde626f7d506555f10dfc815b3eddccfaadfc7d99b11c9a07"},
 ]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,7 +68,7 @@ typecheck = ["mypy"]
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.11.2"
+version = "4.12.0"
 description = "Screen-scraping library"
 category = "dev"
 optional = false
@@ -323,7 +323,7 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "17.6.0"
+version = "18.2.0"
 description = "Faker is a Python package that generates fake data for you."
 category = "dev"
 optional = false
@@ -1232,14 +1232,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "redis"
-version = "4.5.1"
+version = "4.5.2"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-async-timeout = ">=4.0.2"
+async-timeout = {version = ">=4.0.2", markers = "python_version < \"3.11\""}
 importlib-metadata = {version = ">=1.0", markers = "python_version < \"3.8\""}
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
@@ -1656,11 +1656,11 @@ test = ["zope.testrunner"]
 
 [[package]]
 name = "zope.interface"
-version = "5.5.2"
+version = "6.0"
 description = "Interfaces for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "repoze.sphinx.autointerface"]
@@ -1688,8 +1688,8 @@ async-timeout = [
 attrs = []
 bcrypt = []
 beautifulsoup4 = [
-    {file = "beautifulsoup4-4.11.2-py3-none-any.whl", hash = "sha256:0e79446b10b3ecb499c1556f7e228a53e64a2bfcebd455f370d8927cb5b59e39"},
-    {file = "beautifulsoup4-4.11.2.tar.gz", hash = "sha256:bc4bdda6717de5a2987436fb8d72f45dc90dd856bdfd512a1314ce90349a0106"},
+    {file = "beautifulsoup4-4.12.0-py3-none-any.whl", hash = "sha256:2130a5ad7f513200fae61a17abb5e338ca980fa28c439c0571014bc0217e9591"},
+    {file = "beautifulsoup4-4.12.0.tar.gz", hash = "sha256:c5fceeaec29d09c84970e47c65f2f0efe57872f7cff494c9691a26ec0ff13234"},
 ]
 bleach = [
     {file = "bleach-6.0.0-py3-none-any.whl", hash = "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"},
@@ -1895,8 +1895,8 @@ factory-boy = [
     {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
 ]
 faker = [
-    {file = "Faker-17.6.0-py3-none-any.whl", hash = "sha256:5aaa16fa9cfde7d117eef70b6b293a705021e57158f3fa6b44ed1b70202d2065"},
-    {file = "Faker-17.6.0.tar.gz", hash = "sha256:51f37ff9df710159d6d736d0ba1c75e063430a8c806b91334d7794305b5a6114"},
+    {file = "Faker-18.2.0-py3-none-any.whl", hash = "sha256:20272ff42eaa3fd0a83d1c4ad27a6c0a58ebded4e48411a635b31643087d4bd6"},
+    {file = "Faker-18.2.0.tar.gz", hash = "sha256:daf4fc907cdc009bfde011db845d9847e0293baa701c49607bac1184f11e5d95"},
 ]
 flake8 = []
 flake8-blind-except = [
@@ -2383,8 +2383,8 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 redis = [
-    {file = "redis-4.5.1-py3-none-any.whl", hash = "sha256:5deb072d26e67d2be1712603bfb7947ec3431fb0eec9c578994052e33035af6d"},
-    {file = "redis-4.5.1.tar.gz", hash = "sha256:1eec3741cda408d3a5f84b78d089c8b8d895f21b3b050988351e925faf202864"},
+    {file = "redis-4.5.2-py3-none-any.whl", hash = "sha256:4b12b3a1e9bfb43dc533330ec6d142329d0c27ea6bb6716a9d0389e8f2038a4e"},
+    {file = "redis-4.5.2.tar.gz", hash = "sha256:d8ae1a4f725eea6e3958411870fdf944c587b00ea12be28d3bd5575d8f26430c"},
 ]
 requests = [
     {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
@@ -2531,40 +2531,34 @@ zipp = [
     {file = "zope.event-4.6.tar.gz", hash = "sha256:81d98813046fc86cc4136e3698fee628a3282f9c320db18658c21749235fce80"},
 ]
 "zope.interface" = [
-    {file = "zope.interface-5.5.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:a2ad597c8c9e038a5912ac3cf166f82926feff2f6e0dabdab956768de0a258f5"},
-    {file = "zope.interface-5.5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:65c3c06afee96c654e590e046c4a24559e65b0a87dbff256cd4bd6f77e1a33f9"},
-    {file = "zope.interface-5.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d514c269d1f9f5cd05ddfed15298d6c418129f3f064765295659798349c43e6f"},
-    {file = "zope.interface-5.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5334e2ef60d3d9439c08baedaf8b84dc9bb9522d0dacbc10572ef5609ef8db6d"},
-    {file = "zope.interface-5.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc26c8d44472e035d59d6f1177eb712888447f5799743da9c398b0339ed90b1b"},
-    {file = "zope.interface-5.5.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:17ebf6e0b1d07ed009738016abf0d0a0f80388e009d0ac6e0ead26fc162b3b9c"},
-    {file = "zope.interface-5.5.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f98d4bd7bbb15ca701d19b93263cc5edfd480c3475d163f137385f49e5b3a3a7"},
-    {file = "zope.interface-5.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:696f3d5493eae7359887da55c2afa05acc3db5fc625c49529e84bd9992313296"},
-    {file = "zope.interface-5.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7579960be23d1fddecb53898035a0d112ac858c3554018ce615cefc03024e46d"},
-    {file = "zope.interface-5.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:765d703096ca47aa5d93044bf701b00bbce4d903a95b41fff7c3796e747b1f1d"},
-    {file = "zope.interface-5.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e945de62917acbf853ab968d8916290548df18dd62c739d862f359ecd25842a6"},
-    {file = "zope.interface-5.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:655796a906fa3ca67273011c9805c1e1baa047781fca80feeb710328cdbed87f"},
-    {file = "zope.interface-5.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:0fb497c6b088818e3395e302e426850f8236d8d9f4ef5b2836feae812a8f699c"},
-    {file = "zope.interface-5.5.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:008b0b65c05993bb08912f644d140530e775cf1c62a072bf9340c2249e613c32"},
-    {file = "zope.interface-5.5.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:404d1e284eda9e233c90128697c71acffd55e183d70628aa0bbb0e7a3084ed8b"},
-    {file = "zope.interface-5.5.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3218ab1a7748327e08ef83cca63eea7cf20ea7e2ebcb2522072896e5e2fceedf"},
-    {file = "zope.interface-5.5.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d169ccd0756c15bbb2f1acc012f5aab279dffc334d733ca0d9362c5beaebe88e"},
-    {file = "zope.interface-5.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:e1574980b48c8c74f83578d1e77e701f8439a5d93f36a5a0af31337467c08fcf"},
-    {file = "zope.interface-5.5.2-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:0217a9615531c83aeedb12e126611b1b1a3175013bbafe57c702ce40000eb9a0"},
-    {file = "zope.interface-5.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:311196634bb9333aa06f00fc94f59d3a9fddd2305c2c425d86e406ddc6f2260d"},
-    {file = "zope.interface-5.5.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6373d7eb813a143cb7795d3e42bd8ed857c82a90571567e681e1b3841a390d16"},
-    {file = "zope.interface-5.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:959697ef2757406bff71467a09d940ca364e724c534efbf3786e86eee8591452"},
-    {file = "zope.interface-5.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dbaeb9cf0ea0b3bc4b36fae54a016933d64c6d52a94810a63c00f440ecb37dd7"},
-    {file = "zope.interface-5.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604cdba8f1983d0ab78edc29aa71c8df0ada06fb147cea436dc37093a0100a4e"},
-    {file = "zope.interface-5.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e74a578172525c20d7223eac5f8ad187f10940dac06e40113d62f14f3adb1e8f"},
-    {file = "zope.interface-5.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f0980d44b8aded808bec5059018d64692f0127f10510eca71f2f0ace8fb11188"},
-    {file = "zope.interface-5.5.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6e972493cdfe4ad0411fd9abfab7d4d800a7317a93928217f1a5de2bb0f0d87a"},
-    {file = "zope.interface-5.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9d783213fab61832dbb10d385a319cb0e45451088abd45f95b5bb88ed0acca1a"},
-    {file = "zope.interface-5.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:a16025df73d24795a0bde05504911d306307c24a64187752685ff6ea23897cb0"},
-    {file = "zope.interface-5.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:40f4065745e2c2fa0dff0e7ccd7c166a8ac9748974f960cd39f63d2c19f9231f"},
-    {file = "zope.interface-5.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8a2ffadefd0e7206adc86e492ccc60395f7edb5680adedf17a7ee4205c530df4"},
-    {file = "zope.interface-5.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d692374b578360d36568dd05efb8a5a67ab6d1878c29c582e37ddba80e66c396"},
-    {file = "zope.interface-5.5.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4087e253bd3bbbc3e615ecd0b6dd03c4e6a1e46d152d3be6d2ad08fbad742dcc"},
-    {file = "zope.interface-5.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fb68d212efd057596dee9e6582daded9f8ef776538afdf5feceb3059df2d2e7b"},
-    {file = "zope.interface-5.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:7e66f60b0067a10dd289b29dceabd3d0e6d68be1504fc9d0bc209cf07f56d189"},
-    {file = "zope.interface-5.5.2.tar.gz", hash = "sha256:bfee1f3ff62143819499e348f5b8a7f3aa0259f9aca5e0ddae7391d059dce671"},
+    {file = "zope.interface-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f299c020c6679cb389814a3b81200fe55d428012c5e76da7e722491f5d205990"},
+    {file = "zope.interface-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ee4b43f35f5dc15e1fec55ccb53c130adb1d11e8ad8263d68b1284b66a04190d"},
+    {file = "zope.interface-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a158846d0fca0a908c1afb281ddba88744d403f2550dc34405c3691769cdd85"},
+    {file = "zope.interface-6.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f72f23bab1848edb7472309e9898603141644faec9fd57a823ea6b4d1c4c8995"},
+    {file = "zope.interface-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48f4d38cf4b462e75fac78b6f11ad47b06b1c568eb59896db5b6ec1094eb467f"},
+    {file = "zope.interface-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:87b690bbee9876163210fd3f500ee59f5803e4a6607d1b1238833b8885ebd410"},
+    {file = "zope.interface-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f2363e5fd81afb650085c6686f2ee3706975c54f331b426800b53531191fdf28"},
+    {file = "zope.interface-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af169ba897692e9cd984a81cb0f02e46dacdc07d6cf9fd5c91e81f8efaf93d52"},
+    {file = "zope.interface-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa90bac61c9dc3e1a563e5babb3fd2c0c1c80567e815442ddbe561eadc803b30"},
+    {file = "zope.interface-6.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89086c9d3490a0f265a3c4b794037a84541ff5ffa28bb9c24cc9f66566968464"},
+    {file = "zope.interface-6.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:809fe3bf1a91393abc7e92d607976bbb8586512913a79f2bf7d7ec15bd8ea518"},
+    {file = "zope.interface-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:0ec9653825f837fbddc4e4b603d90269b501486c11800d7c761eee7ce46d1bbb"},
+    {file = "zope.interface-6.0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:790c1d9d8f9c92819c31ea660cd43c3d5451df1df61e2e814a6f99cebb292788"},
+    {file = "zope.interface-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b39b8711578dcfd45fc0140993403b8a81e879ec25d53189f3faa1f006087dca"},
+    {file = "zope.interface-6.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eba51599370c87088d8882ab74f637de0c4f04a6d08a312dce49368ba9ed5c2a"},
+    {file = "zope.interface-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ee934f023f875ec2cfd2b05a937bd817efcc6c4c3f55c5778cbf78e58362ddc"},
+    {file = "zope.interface-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:042f2381118b093714081fd82c98e3b189b68db38ee7d35b63c327c470ef8373"},
+    {file = "zope.interface-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:dfbbbf0809a3606046a41f8561c3eada9db811be94138f42d9135a5c47e75f6f"},
+    {file = "zope.interface-6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:424d23b97fa1542d7be882eae0c0fc3d6827784105264a8169a26ce16db260d8"},
+    {file = "zope.interface-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e538f2d4a6ffb6edfb303ce70ae7e88629ac6e5581870e66c306d9ad7b564a58"},
+    {file = "zope.interface-6.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:12175ca6b4db7621aedd7c30aa7cfa0a2d65ea3a0105393e05482d7a2d367446"},
+    {file = "zope.interface-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c3d7dfd897a588ec27e391edbe3dd320a03684457470415870254e714126b1f"},
+    {file = "zope.interface-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b3f543ae9d3408549a9900720f18c0194ac0fe810cecda2a584fd4dca2eb3bb8"},
+    {file = "zope.interface-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d0583b75f2e70ec93f100931660328965bb9ff65ae54695fb3fa0a1255daa6f2"},
+    {file = "zope.interface-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:23ac41d52fd15dd8be77e3257bc51bbb82469cf7f5e9a30b75e903e21439d16c"},
+    {file = "zope.interface-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99856d6c98a326abbcc2363827e16bd6044f70f2ef42f453c0bd5440c4ce24e5"},
+    {file = "zope.interface-6.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1592f68ae11e557b9ff2bc96ac8fc30b187e77c45a3c9cd876e3368c53dc5ba8"},
+    {file = "zope.interface-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4407b1435572e3e1610797c9203ad2753666c62883b921318c5403fb7139dec2"},
+    {file = "zope.interface-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:5171eb073474a5038321409a630904fd61f12dd1856dd7e9d19cd6fe092cbbc5"},
+    {file = "zope.interface-6.0.tar.gz", hash = "sha256:aab584725afd10c710b8f1e6e208dbee2d0ad009f57d674cb9d1b3964037275d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,6 +28,20 @@ python-versions = "*"
 dev = ["black", "coverage", "isort", "pre-commit", "pyenchant", "pylint"]
 
 [[package]]
+name = "asgiref"
+version = "3.6.0"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
@@ -414,6 +428,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
+asgiref = {version = ">=3.2", optional = true, markers = "extra == \"async\""}
 click = ">=8.0"
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.0"
@@ -1670,7 +1685,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "c3a1d4f27483522585032349d5a7c023169fa2d440928b6255180c52fa1c6055"
+content-hash = "9431a137c3410156f2033665a786b833e5a2d313c814dcc2b565461a689c1afe"
 
 [metadata.files]
 alembic = [
@@ -1680,6 +1695,10 @@ alembic = [
 aniso8601 = [
     {file = "aniso8601-9.0.1-py2.py3-none-any.whl", hash = "sha256:1d2b7ef82963909e93c4f24ce48d4de9e66009a21bf1c1e1c85bdd0812fe412f"},
     {file = "aniso8601-9.0.1.tar.gz", hash = "sha256:72e3117667eedf66951bb2d93f4296a56b94b078a8a95905a052611fb3f1b973"},
+]
+asgiref = [
+    {file = "asgiref-3.6.0-py3-none-any.whl", hash = "sha256:71e68008da809b957b7ee4b43dbccff33d1b23519fb8344e33f049897077afac"},
+    {file = "asgiref-3.6.0.tar.gz", hash = "sha256:9567dfe7bd8d3c8c892227827c41cce860b368104c3431da67a0c5a65a949506"},
 ]
 async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -323,7 +323,7 @@ doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "18.2.0"
+version = "18.3.0"
 description = "Faker is a Python package that generates fake data for you."
 category = "dev"
 optional = false
@@ -1232,7 +1232,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "redis"
-version = "4.5.2"
+version = "4.5.3"
 description = "Python client for Redis database and key-value store"
 category = "main"
 optional = false
@@ -1895,8 +1895,8 @@ factory-boy = [
     {file = "factory_boy-3.2.1.tar.gz", hash = "sha256:a98d277b0c047c75eb6e4ab8508a7f81fb03d2cb21986f627913546ef7a2a55e"},
 ]
 faker = [
-    {file = "Faker-18.2.0-py3-none-any.whl", hash = "sha256:20272ff42eaa3fd0a83d1c4ad27a6c0a58ebded4e48411a635b31643087d4bd6"},
-    {file = "Faker-18.2.0.tar.gz", hash = "sha256:daf4fc907cdc009bfde011db845d9847e0293baa701c49607bac1184f11e5d95"},
+    {file = "Faker-18.3.0-py3-none-any.whl", hash = "sha256:2deeee8fed3d1b8ae5f87d172d4569ddc859aab8693f7cd68eddc5d20400563a"},
+    {file = "Faker-18.3.0.tar.gz", hash = "sha256:e7c058e1f360f245f265625b32d3189d7229398ad80a8b6bac459891745de052"},
 ]
 flake8 = []
 flake8-blind-except = [
@@ -2383,8 +2383,8 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 redis = [
-    {file = "redis-4.5.2-py3-none-any.whl", hash = "sha256:4b12b3a1e9bfb43dc533330ec6d142329d0c27ea6bb6716a9d0389e8f2038a4e"},
-    {file = "redis-4.5.2.tar.gz", hash = "sha256:d8ae1a4f725eea6e3958411870fdf944c587b00ea12be28d3bd5575d8f26430c"},
+    {file = "redis-4.5.3-py3-none-any.whl", hash = "sha256:7df17a0a2b72a4c8895b462dd07616c51b1dcb48fdd7ecb7b6f4bf39ecb2e94e"},
+    {file = "redis-4.5.3.tar.gz", hash = "sha256:56732e156fe31801c4f43396bd3ca0c2a7f6f83d7936798531b9848d103381aa"},
 ]
 requests = [
     {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},

--- a/publish-docker.sh
+++ b/publish-docker.sh
@@ -1,0 +1,3 @@
+docker login
+docker build -t loleg/dribdat:stable .
+docker push loleg/dribdat:stable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ boto3 = ">=1.19.12,<1.20"
 click = ">=6.7"
 cssmin = ">=0.2.0"
 email-validator = "^1.1.2"
-flask = ">=0.12.2"
+flask = {extras = ["async"], version = ">=0.12.2"}
 flask-assets = ">=0.12"
 flask-bcrypt = ">=0.7.1"
 flask-caching = ">=1.3.3"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -71,7 +71,7 @@ pystache==0.6.0; python_version >= "3.6"
 python-dateutil==2.8.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 python-dotenv==0.21.1; python_version >= "3.7"
 python-slugify==8.0.1; python_version >= "3.7"
-pytz==2022.7.1
+pytz==2023.2
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 redis==4.5.3; python_version >= "3.7"
 requests-oauthlib==1.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,7 +1,7 @@
 -i https://pypi.org/simple
 alembic==1.10.2; python_version >= "3.7"
 aniso8601==9.0.1
-async-timeout==4.0.2; python_version >= "3.7"
+async-timeout==4.0.2; python_version < "3.11" and python_version >= "3.7"
 attrs==22.2.0; python_version >= "3.7"
 bcrypt==4.0.1; python_version >= "3.6"
 bleach==6.0.0; python_version >= "3.7"
@@ -73,7 +73,7 @@ python-dotenv==0.21.1; python_version >= "3.7"
 python-slugify==8.0.1; python_version >= "3.7"
 pytz==2022.7.1
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-redis==4.5.1; python_version >= "3.7"
+redis==4.5.2; python_version >= "3.7"
 requests-oauthlib==1.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 requests==2.28.2; python_version >= "3.7" and python_version < "4"
 rfc3986==2.0.0; python_version >= "3.7"
@@ -100,4 +100,4 @@ whitenoise==5.3.0; python_version >= "3.5" and python_version < "4"
 wtforms==3.0.1; python_version >= "3.7"
 zipp==3.15.0; python_version < "3.8" and python_version >= "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.6.0" and python_version < "3.8" and python_version >= "3.6")
 zope.event==4.6; python_version >= "3.5" and python_full_version < "3.0.0" or python_version > "3.5"
-zope.interface==5.5.2; python_version >= "3.5" and python_full_version < "3.0.0" or python_version > "3.5" and python_full_version < "3.0.0" or python_version > "3.5" and python_full_version >= "3.5.0"
+zope.interface==6.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_version >= "3.7"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,7 @@
 -i https://pypi.org/simple
 alembic==1.10.2; python_version >= "3.7"
 aniso8601==9.0.1
+asgiref==3.6.0; python_version >= "3.7" and python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 async-timeout==4.0.2; python_version < "3.11" and python_version >= "3.7"
 attrs==22.2.0; python_version >= "3.7"
 bcrypt==4.0.1; python_version >= "3.6"
@@ -89,7 +90,7 @@ stringcase==1.2.0
 tabulate==0.9.0; python_version >= "3.7"
 text-unidecode==1.3; python_version >= "3.7"
 typer==0.7.0; python_version >= "3.6"
-typing-extensions==4.5.0; python_version < "3.8" and python_version >= "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.6.0" and python_version < "3.8" and python_version >= "3.6") and python_full_version >= "3.6.3" and python_full_version < "4.0.0"
+typing-extensions==4.5.0
 urllib3==1.26.15; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.7" and python_version < "4" and python_full_version >= "3.6.0"
 urlobject==2.4.3; python_version >= "3.6"
 validators==0.20.0; python_version >= "3.4"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -73,7 +73,7 @@ python-dotenv==0.21.1; python_version >= "3.7"
 python-slugify==8.0.1; python_version >= "3.7"
 pytz==2022.7.1
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-redis==4.5.2; python_version >= "3.7"
+redis==4.5.3; python_version >= "3.7"
 requests-oauthlib==1.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 requests==2.28.2; python_version >= "3.7" and python_version < "4"
 rfc3986==2.0.0; python_version >= "3.7"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -43,8 +43,8 @@ EOF""" % (url, url)
         assert stats['commits'] == 0
         assert stats['during'] == 0
         assert stats['people'] == 0
-        assert stats['wordslong'] == 1
-        assert stats['wordcount'] == 9
+        assert stats['sizepitch'] == 5
+        assert stats['sizetotal'] == 48
         
     def test_project_stage(self, project, testapp):
         """Check stage progression."""

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -62,6 +62,7 @@ class TestImport:
         proj1 = Project(name="Test Project")
         proj1.event = event
         proj1.user = user
+        proj1.progress = 10
         proj1.save()
         ProjectActivity(proj1, "star", user)
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -69,6 +69,7 @@ class TestImport:
         # Now we are a member of one project
         schema = get_schema_for_user_projects(user, hosturl)
         assert len(schema) == 1
+        assert 'message' not in schema
         assert len(schema[0]["workPerformed"]) == 1
 
         # Create another project


### PR DESCRIPTION
- Performance improvements to Data Package API.
- Statistics reflect byte-count, not word count, of project texts.
- More subtle (iconographic - see screenshot below) project follower indicator.
- Users can be searched for by email as well as by username.
- Pagination in Admin conserves sort setting.
- Markdown files from GitHub can be directly synced, not just READMEs.
- Additional messaging for SSO in the login area.
- Adds `numerise` command to the CLI for assigning prime numbers to challenges via Hashtag field.
- Project count sped up slightly, caching revised.
- Bump PDF viewer (pdf.js), slightly improve navigation buttons.
- Dashboard scheme revised.
- Add Post button to top navigation.
- Add async to mailer.
- Plain option for numerise.
- Skip hidden projects in joined_projects.
- Add `OAUTH_LINK_REGISTER` (a link to external registration page) option.
- Allow users to login with e-mail or username.
- Toast UI editor version bump.

![Screenshot_20230322-075201.png](https://user-images.githubusercontent.com/31819/226824592-69a15ccc-cc07-4d9a-8992-cf34dea07eca.png)

