### PR TITLE
Refactor dockerfile and add entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,4 +22,16 @@
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
-README.md
+**/.github
+docs
+profile
+tests
+**/LICENSE
+**/README.md
+**/PACKAGE.txt
+**/.pyup.yml
+**/app.json
+**/deploy-stackscript.sh
+**/package.json
+**/Procfile
+**/publish-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,51 @@
+# Based on python image which itself is based on debian image
+# https://hub.docker.com/_/python
+# https://hub.docker.com/_/debian
 FROM python:3.9-slim
 
-# Install compiler
-RUN apt-get update && apt-get install gcc -y && apt-get clean
+# Maintainer information
+LABEL maintainer="Dribdat <dribdat@datalets.ch>"
 
-# Not needed for production
-#RUN apt-get install -y nodejs npm
-# Install node requirements (after WORKDIR)
-#RUN npm install
-
-EXPOSE 5000
-
+# Environment
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
-
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
-# Install pip requirements
+# Copy pip requirements
 COPY requirements.txt .
 COPY requirements/* requirements/
-RUN python -m pip install --upgrade pip
-RUN python -m pip install -r requirements.txt
-
-# Copy dribdat app
-WORKDIR /app
+# Copy app files (please see dockerignore)
 COPY . /app
 
-# Creates a non-root user with an explicit UID and adds permission to access the /app folder
-# For more info, please refer to https://aka.ms/vscode-docker-python-configure-containers
-RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
+# Run commands
+RUN set -x \
+    && mkdir /docker-entrypoint.d \
+    && mv /app/image/docker-entrypoint.d/* /docker-entrypoint.d/ \
+    && mv /app/image/docker-entrypoint.sh /docker-entrypoint.sh \
+    && chmod +x /docker-entrypoint.sh \
+    && rm -rf /app/image \
+    # Creates a non-root user with an explicit UID and adds permission to access the /app folder
+    && adduser --uid 5678 --disabled-password --gecos "" appuser \
+    && chown -R appuser /app \
+    && chown -R appuser /docker-entrypoint.d \
+    && chown appuser /docker-entrypoint.sh \
+    # Install compiler (used by some pip packages)
+    && apt-get update \
+    && apt-get install gcc -y \
+    && apt-get clean \
+    # Install requirements
+    && python -m pip install --upgrade pip \
+    && python -m pip install -r requirements.txt \
+    # Clean up after build
+    && apt-get purge --auto-remove -y
+
+WORKDIR /app
 USER appuser
 
-# Run release commands
-RUN ./release.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]
+EXPOSE 5000
+CMD ["/usr/local/bin/gunicorn","--config=gunicorn.conf.py","patched:init_app()"]
 
-# During debugging, this entry point will be overridden. For more information,
-# please refer to https://aka.ms/vscode-docker-python-debug
-CMD gunicorn --config=gunicorn.conf.py patched:init_app\(\)
+
+

--- a/force-migrate.sh
+++ b/force-migrate.sh
@@ -5,9 +5,9 @@ if [ "$1" = "psql" ]; then
 	echo "Force migrating database"
 	rm -rf migrations/
 	psql -c "DROP TABLE alembic_version;" $DATABASE_URL
-	python manage.py db init 2>&1 >/dev/null
-	python manage.py db migrate
-	python manage.py db upgrade
+	python "${APPDIR:-.}/manage.py" db init 2>&1 >/dev/null
+	python "${APPDIR:-.}/manage.py" db migrate
+	python "${APPDIR:-.}/manage.py" db upgrade
 	echo "Upgrade complete, 10 second cooldown"
 	sleep 10
 
@@ -19,13 +19,13 @@ elif [ "$1" = "heroku" ]; then
 	echo "Migrating Heroku DB on $2 in 5 seconds - Ctrl-C to abort."
 	sleep 5s
 	heroku pg:psql -a $2 -c "drop table alembic_version"
-	heroku run -a $2 "python manage.py db init && python manage.py db migrate && python manage.py db upgrade"
+	heroku run -a $2 "python ${APPDIR:-.}/manage.py db init && python ${APPDIR:-.}/manage.py db migrate && python ${APPDIR:-.}/manage.py db upgrade"
 
 elif [ "$1" = "local" ]; then
 	echo "Resetting local SQLite DB (dev.db)"
-	rm -rf dev.db
-	python manage.py db migrate
-	python manage.py db upgrade
+	rm -rf "${APPDIR:-.}/dev.db"
+	python "${APPDIR:-.}/manage.py" db migrate
+	python "${APPDIR:-.}/manage.py" db upgrade
 
 else
 	echo "Use this script with the following arguments to refresh the DB schema:"

--- a/image/docker-entrypoint.d/10-migrate.sh
+++ b/image/docker-entrypoint.d/10-migrate.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+APPDIR=/app /app/release.sh

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -37,9 +37,5 @@ if [ -z "${DRIBDAT_ENTRYPOINT_SKIP:-}" ]; then
     fi
 fi
 
-echo "$@"
-echo "$PATH"
-type gunicorn
-
 # execute the command passed to the container
 exec "$@"

--- a/image/docker-entrypoint.sh
+++ b/image/docker-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+
+log() {
+    if [ -z "${DRIBDAT_ENTRYPOINT_NO_LOGS:-}" ]; then
+        echo "$@"
+    fi
+}
+
+if [ -z "${DRIBDAT_ENTRYPOINT_SKIP:-}" ]; then
+    if /usr/bin/find "/docker-entrypoint.d/" -mindepth 1 -maxdepth 1 -type f -print -quit 2>/dev/null | read v; then
+        log "$0: /docker-entrypoint.d/ not empty, processing it"
+        find "/docker-entrypoint.d/" -follow -type f -print | sort -V | while read -r f; do
+            case "$f" in
+                *.envsh)
+                    if [ -x "$f" ]; then
+                        log "$0: Sourcing $f";
+                        . "$f"
+                    else
+                        log "$0: Ignoring $f, executable bit not set";
+                    fi
+                    ;;
+                *.sh)
+                    if [ -x "$f" ]; then
+                        log "$0: Executing $f";
+                        "$f"
+                    else
+                        log "$0: Ignoring $f, executable bit not set";
+                    fi
+                    ;;
+                *) log "$0: Ignoring $f";;
+            esac
+        done
+    else
+        log "$0: Nothing found in /docker-entrypoint.d/, skipping"
+    fi
+fi
+
+echo "$@"
+echo "$PATH"
+type gunicorn
+
+# execute the command passed to the container
+exec "$@"

--- a/release.sh
+++ b/release.sh
@@ -1,17 +1,19 @@
 #!/bin/bash
 # Release script
 
+# set APPDIR if running from a different directory, e.g. in container
+
 if [ "$FORCE_MIGRATE" ]; then
-	./force-migrate.sh psql
+	"${APPDIR:-.}/force-migrate.sh" psql
 
 else
 	# Silent upgrade
-	python manage.py db upgrade 2>&1 >/dev/null
+	python "${APPDIR:-.}/manage.py" db upgrade 2>&1 >/dev/null
 	echo "Warning! Your database may be out of sync due to a forced upgrade."
 fi
 
 # Compress assets
-python -m whitenoise.compress dribdat/static/js
-python -m whitenoise.compress dribdat/static/css
-python -m whitenoise.compress dribdat/static/img
-python -m whitenoise.compress dribdat/static/public
+python -m whitenoise.compress "${APPDIR:-.}/dribdat/static/js"
+python -m whitenoise.compress "${APPDIR:-.}/dribdat/static/css"
+python -m whitenoise.compress "${APPDIR:-.}/dribdat/static/img"
+python -m whitenoise.compress "${APPDIR:-.}/dribdat/static/public"


### PR DESCRIPTION
The line `RUN ./release.sh` in the Dockerfile seems to be used for db migration. However, it only runs at build-time of the container, not at run-time. I added an entrypoint script which will parse `/docker-entrypoint.d` for sourcable and executable files which should make the image a bit more extendable in general. I couldn't test it because I have no db but it should now migrate the db when the container is started. I hope the script checks whether migration is even needed.

Security-wise the `COPY . /app` line is a bit dangerous because it copies the whole workdir into the container image. This means that especially when the build is done in a pipeline extra care is needed in order to update the `.dockerignore` file to avoid leaking secrets and information about the environment. For now I just extended it a little bit so that unnecessary stuff isn't present in the image.

I also squashed all the `RUN` instructions into a single one to avoid spamming the image with many layers.