### PR TITLE
Generate RSS feeds

### DIFF
--- a/dribdat/apipackage.py
+++ b/dribdat/apipackage.py
@@ -29,7 +29,7 @@ def event_to_data_package(event, author=None, host_url='', full_content=False):
     contributors = []
     if author and not author.is_anonymous and author.is_admin:
         contributors.append({
-            "title": author.username,
+            "title": author.name,
             "path": author.webpage_url or '',
             "role": "author"
         })

--- a/dribdat/app.py
+++ b/dribdat/app.py
@@ -95,10 +95,11 @@ def init_talisman(app):
 
 def register_blueprints(app):
     """Register Flask blueprints."""
-    app.register_blueprint(public.views.blueprint)
-    app.register_blueprint(public.project.blueprint)
-    app.register_blueprint(public.auth.blueprint)
     app.register_blueprint(public.api.blueprint)
+    app.register_blueprint(public.auth.blueprint)
+    app.register_blueprint(public.views.blueprint)
+    app.register_blueprint(public.feeds.blueprint)
+    app.register_blueprint(public.project.blueprint)
     app.register_blueprint(admin.views.blueprint)
     return None
 

--- a/dribdat/mailer.py
+++ b/dribdat/mailer.py
@@ -17,7 +17,7 @@ def user_activation_message(user, act_hash):
     msg = EmailMessage(from_email=from_email)
     msg.subject = 'Your dribdat account'
     msg.body = \
-        "Hello %s,\n" % user.username \
+        "Hello %s,\n" % user.name \
         + "Thanks for signing up at %s\n\n" % base_url \
         + "Tap here to activate your account:\n\n%s" % act_url
     logging.debug(act_url)

--- a/dribdat/public/__init__.py
+++ b/dribdat/public/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """The public module, including the homepage, API and user auth."""
-from . import views, project, auth, api  # noqa
+from . import views, project, auth, api, feeds  # noqa

--- a/dribdat/public/feeds.py
+++ b/dribdat/public/feeds.py
@@ -19,7 +19,7 @@ from ..apiutils import (
 blueprint = Blueprint('feeds', __name__, url_prefix='/feeds')
 
 MAX_ITEMS = 20
-RSS_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S UTC'
+RSS_DATE_FORMAT = '%a, %d %b %Y %H:%M:%S GMT'
 
 # ------ FEEDS ---------
 

--- a/dribdat/public/feeds.py
+++ b/dribdat/public/feeds.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""Feeds for dribdat."""
+import boto3
+import datetime as dt
+
+from flask import (
+    Blueprint, current_app, render_template,
+    Response, request, redirect, url_for
+)
+from flask_login import current_user
+from sqlalchemy import or_
+from datetime import datetime
+from ..user.models import Event, Project, Activity, User
+from ..apiutils import (
+    get_event_activities,
+)
+
+blueprint = Blueprint('feeds', __name__, url_prefix='/feeds')
+
+MAX_ITEMS = 20
+RSS_DATE_FORMAT = '%a %d %b %Y %H:%M %Z'
+
+# ------ FEEDS ---------
+
+def rssheader(resp):    
+    resp.headers['Content-Type'] = 'application/rss+xml'
+    return resp
+
+
+@blueprint.route("/dribs")
+def get_dribs():
+    """Show the latest logged posts."""
+    dribs = Activity \
+            .query \
+            .filter(or_(
+                Activity.action == "post",
+                Activity.name == "boost")) \
+            .order_by(Activity.id.desc()) \
+            .limit(MAX_ITEMS)
+    activities = [
+        d for d in dribs
+        if not d.project.is_hidden and d.content]
+    if len(activities) > 0:
+        event = activities[0].project.event
+    else:
+        event = current_event()
+    now = datetime.utcnow().strftime(RSS_DATE_FORMAT)
+    fqdn = url_for("public.event", event_id=event.id, _external=True)
+    atomlink = url_for("feeds.get_dribs", _external=True)
+    return render_template("public/rss.xml",
+                           now=now,
+                           title=event.name,
+                           fqdn=fqdn,
+                           description=event.summary,
+                           atomlink=atomlink,
+                           activities=activities)
+
+
+@blueprint.route('/user/<username>', methods=['GET'])
+def get_user(username):
+    """Output feed by username."""
+    a_user = User.query.filter_by(username=username).first_or_404()
+    url_profile = url_for("public.user", username=un, _external=True)
+    activities = a_user.latest_posts(MAX_ITEMS)
+    return 'Not implemented'

--- a/dribdat/templates/admin/projects.html
+++ b/dribdat/templates/admin/projects.html
@@ -65,7 +65,7 @@
             </td>
             <td>{{ project.category.name }}</td>
             <td>{{ project.created_at|format_date }}
-              <small><br>{{ project.user.username }}</small></td>
+              <small><br>{{ project.user.name }}</small></td>
             <td>{{ project.updated_at|since_date }}</td>
             <td><div class="btn-group">
               <a href="{{ url_for('admin.project_view', project_id=project.id) }}" class="btn btn-warning">

--- a/dribdat/templates/layout.html
+++ b/dribdat/templates/layout.html
@@ -50,6 +50,7 @@
     <link rel="stylesheet" href="{{ config.DRIBDAT_STYLE }}"/>
   {% endif %}
   <link rel="shortcut icon" href="{{ url_for('static', filename='img/favicon.ico')}}"/>
+  <link rel="alternate" type="application/rss+xml" title="RSS: Latest dribs" href="/feeds/dribs.xml">
 
 </head>
 <body class="{% block body_class %}{% endblock %}" data-barba="wrapper">

--- a/dribdat/templates/macros/_misc.html
+++ b/dribdat/templates/macros/_misc.html
@@ -4,7 +4,7 @@
         {% if user.carddata %}
             <img src="{{user.carddata}}"/>
         {% endif %}
-        <span>{{ user.username }}</span>
+        <span>{{ user.name }}</span>
         <div class="team-roles">
         {% for role in user.roles %}
           {% if role.name %}

--- a/dribdat/templates/public/about.html
+++ b/dribdat/templates/public/about.html
@@ -32,7 +32,7 @@
         Or contact one of the organisers on this site:</p>
       <p class="organisers font-weight-bold">
       {% for user in orgs %}
-        &nbsp;🕴️<a href="{{ url_for('public.user', username=user.username) }}">{{ user.username }}</a>
+        &nbsp;🕴️<a href="{{ url_for('public.user', username=user.username) }}">{{ user.name }}</a>
       {% endfor %}
       </p>
     </div><!-- /organiser -->

--- a/dribdat/templates/public/dribs.html
+++ b/dribdat/templates/public/dribs.html
@@ -58,7 +58,7 @@
                 ~
                 <a class="userlink"
                   href="{{ url_for('public.user', username=s.user.username )}}">
-                  {{ s.user.username }}</a>
+                  {{ s.user.name }}</a>
               {% endif %}
             </div>
           {% if s.ref_url %}

--- a/dribdat/templates/public/eventprint.html
+++ b/dribdat/templates/public/eventprint.html
@@ -43,7 +43,7 @@
       <li>Updated: <span>{{ project.updated_at|format_date }}</span> ({{project.score}}% complete)</li>
       <li>Created: <span>{{ project.created_at|format_date }}</span>
         {% if project.user %}
-        by <a href="{{project.user.webpage_url}}">{{ project.user.username }}</a>
+        by <a href="{{project.user.webpage_url}}">{{ project.user.name }}</a>
         {% endif %}</li>
       {% if project.category_id %}
       <li>Category: <b>{{ project.category.name }}</b></li>
@@ -108,7 +108,7 @@
       <li>Updated: <span>{{ project.updated_at|format_date }}</span></li>
       <li>Created: <span>{{ project.created_at|format_date }}</span>
         {% if project.user %}
-        by <a href="{{project.user.webpage_url}}">{{ project.user.username }}</a>
+        by <a href="{{project.user.webpage_url}}">{{ project.user.name }}</a>
         {% endif %}</li>
       {% if project.category_id %}
       <li>Category: <b>{{ project.category.name }}</b></li>

--- a/dribdat/templates/public/rss.xml
+++ b/dribdat/templates/public/rss.xml
@@ -10,12 +10,12 @@
 	  <atom:link href='{{ atomlink }}' rel='self' type='application/rss+xml' />
 	  {% for s in activities %}
     <item>
-      <title>{{ s.project.name }}</title>
+      <title>{{ s.project_name or s.project.name }}</title>
     {% if s.ref_url %}
       <link>{{ s.ref_url }}</link>
     {% endif %}
       <description>{{ s.name }}</description>
-      <pubDate>{{ s.data.date }}</pubDate>
+      <pubDate>{{ s.date or s.data.date }}</pubDate>
       <guid>{{ atomlink }}/{{ s.id }}</guid>
     {% if s.content %}
       <content:encoded><![CDATA[{{ s.content|markdown|safe }}]]></content:encoded>

--- a/dribdat/templates/public/rss.xml
+++ b/dribdat/templates/public/rss.xml
@@ -10,12 +10,12 @@
 	  <atom:link href='{{ atomlink }}' rel='self' type='application/rss+xml' />
 	  {% for s in activities %}
     <item>
-      <title>{{ s.project_name or s.project.name }}</title>
+      <title>{{ s.project_name }}</title>
     {% if s.ref_url %}
       <link>{{ s.ref_url }}</link>
     {% endif %}
       <description>{{ s.name }}</description>
-      <pubDate>{{ s.date or s.data.date }}</pubDate>
+      <pubDate>{{ s.rssdate }}</pubDate>
       <guid>{{ atomlink }}/{{ s.id }}</guid>
     {% if s.content %}
       <content:encoded><![CDATA[{{ s.content|markdown|safe }}]]></content:encoded>

--- a/dribdat/templates/public/rss.xml
+++ b/dribdat/templates/public/rss.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0'?>
+<rss version='2.0'
+	xmlns:atom='http://www.w3.org/2005/Atom'
+	xmlns:content='http://purl.org/rss/1.0/modules/content/'>
+  <channel>
+    <pubDate>{{ now }}</pubDate>
+    <title>{{ title }}</title>
+    <link>{{ fqdn }}</link>
+    <description>{{ description }}</description>
+	  <atom:link href='{{ atomlink }}' rel='self' type='application/rss+xml' />
+	  {% for s in activities %}
+    <item>
+      <title>{{ s.project.name }}</title>
+    {% if s.ref_url %}
+      <link>{{ s.ref_url }}</link>
+    {% endif %}
+      <description>{{ s.name }}</description>
+      <pubDate>{{ s.data.date }}</pubDate>
+      <guid>{{ atomlink }}/{{ s.id }}</guid>
+    {% if s.content %}
+      <content:encoded><![CDATA[{{ s.content|markdown|safe }}]]></content:encoded>
+    {% endif %}
+    </item>
+	{% endfor %}
+  </channel>
+</rss>

--- a/dribdat/templates/public/userprofile.html
+++ b/dribdat/templates/public/userprofile.html
@@ -4,6 +4,10 @@
 {% block page_title %}{{ user.username }}{% endblock %}
 {% block body_class %}userprofile{% endblock %}
 
+{% block page_meta %}
+  <link rel="alternate" type="application/rss+xml" title="RSS: Dribs by {{ user.name }}" href="/feeds/user/{{ user.username }}">
+{% endblock %}
+
 {% block content %}
 
 {% if current_user and current_user.is_authenticated %}

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,7 +13,6 @@ class BaseFactory(SQLAlchemyModelFactory):
 
     class Meta:
         """Factory configuration."""
-
         abstract = True
         sqlalchemy_session = db.session
 


### PR DESCRIPTION
- The public feed (latest dribs) and user feed are available in RSS format.
- Standard links are added to the page header.
- Resolves #248 

<a href="http://validator.w3.org/check.cgi?url=https%3A//meta.dribdat.cc/feeds/dribs.xml"><img src="https://validator.w3.org/feed/images/valid-rss-rogers.png" alt="[Valid RSS]" title="Validate my RSS feed" /></a>

## Screenshots

![Screenshot from 2023-11-29 11-06-45](https://github.com/dribdat/dribdat/assets/31819/299945bc-cb82-419c-95e4-07f551947352)

Just add the URL of the Dribdat site to your Feed reader (pictured: [NewsFlash](https://apps.gnome.org/de/NewsFlash/)).

![Screenshot from 2023-11-29 11-09-50](https://github.com/dribdat/dribdat/assets/31819/896f76b4-9e48-47b3-85a7-115d64fe79fb)

The content of Dribs appears as you would expect. 