### PR TITLE
Docker Compose working out of the box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ docs/_build
 env/
 debug.sh
 .db/
+data/
 
 # JavaScript
 node_modules

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - 5000:5000
     environment:
-      - SERVER_URL=localhost.changeme:5000
+      - SERVER_URL=localhost:5000
       - DATABASE_URL=postgres://dribdat_user:changeme@db:5432/dribdat
       - DRIBDAT_ENV=prod
       - DRIBDAT_SECRET=changeme
@@ -18,7 +18,7 @@ services:
   db:
     image: postgres
     volumes:
-      - ./.db:/var/lib/postgresql/data
+      - ./data/.db:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=dribdat
       - POSTGRES_USER=dribdat_user

--- a/docker-compose.sqlite.yml
+++ b/docker-compose.sqlite.yml
@@ -12,4 +12,4 @@ services:
       - DRIBDAT_ALLOW_EVENTS=1
       - DRIBDAT_SOCIAL_LINKS=0
     volumes:
-      - ./data/:/opt
+      - ./data/:/opt:rw


### PR DESCRIPTION
From the [overview on dribdat.cc](https://dribdat.cc/deploy#with-docker-compose), the sqlite sample:
`docker compose -f docker-compose.sqlite.yml up -d`
didn't work for me out of the box due to a missing database and permissions issues.

This fix adds an empty database in the expected location `data/dribdat.db` and adds the read-write flag to the volume command.

In debugging it, I used the PostgreSQL sample (after modifying the `SERVER_URL` parameter):
`docker compose -f docker-compose.local.yml up -d`
and found that it put a root owned `.db` directory in my Git clone - which is ignored according to `.gitignore` - but I thought a better place might be the new data directory, so I went ahead and modified the local docker compose too.
If you want, I can pull this out of the PR.

I don't think the documentation needs to change.